### PR TITLE
Add 'await' on call to pr merge and branch delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function run() {
             if (pull.canMerge(config)) {
 
                 // merge the pull request
-                octokit.pulls.merge({
+                await octokit.pulls.merge({
                     owner: pull.owner,
                     repo: pull.repo,
                     pull_number: pull.pull_number,
@@ -58,7 +58,7 @@ async function run() {
                 });
 
                 // delete the branch
-                octokit.git.deleteRef({
+                await octokit.git.deleteRef({
                     owner: pull.owner,
                     repo: pull.repo,
                     ref: pull.ref


### PR DESCRIPTION
I am no Javascript developer, but I think there should be some `await` here :D

So the bot was failing to merge my PR, it would just delete the branch and close the PR. Now I added these awaits and used my fork, I get a build fail on the merge step saying this:

```
##[error]You're not authorized to push to this branch. Visit https://docs.github.com/articles/about-protected-branches/ for more information.
```

I'm not sure exactly why it is failing / being blocked, but that is a separate problem! At least we wait for the call to merge to return successfully before going ahead and deleting the branch now!