### PR TITLE
Add basic handling for changelog config parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,12 +54,16 @@ async function run() {
 
                 // merge the pull request
                 console.log(`[info] merge start`);
-                await octokit.pulls.merge({
+                const changelogDetails = config.changelog ? {
+                    commit_title: pull.title,
+                    commit_message: pull.parseChangelog()
+                } : {}
+                await octokit.pulls.merge(Object.assign({}, {
                     owner: pull.owner,
                     repo: pull.repo,
                     pull_number: pull.pull_number,
                     merge_method: config.merge_method
-                });
+                }, changelogDetails));
                 console.log(`[info] merge complete`);
 
                 if (config.delete_source_branch) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,6 +7,7 @@ class Config {
         this.checks_enabled = core.getInput('checks_enabled') === 'true';
         this.test_mode = core.getInput('test') === 'true';
         this.delete_source_branch = core.getInput('delete_source_branch') === 'true';
+        this.changelog = core.getInput('changelog') === 'true';
     }
 }
 

--- a/lib/message.js
+++ b/lib/message.js
@@ -1,4 +1,5 @@
 const renderMessage = (action, config, pull) => {
+    const changelog = pull.parseChangelog()
     return `### merge bot test mode
 
 #### overview
@@ -15,6 +16,7 @@ const renderMessage = (action, config, pull) => {
 <tr><td>blocking label(s)</td><td>${JSON.stringify(config.blocking_labels)}</td></tr>
 <tr><td>reviewers required</td><td>${config.review_required}</td></tr>
 <tr><td>merge method</td><td>${config.merge_method}</td></tr>
+<tr><td>changelog</td><td>${config.changelog}</td></tr>
 </table>
 
 #### pull request details
@@ -24,7 +26,7 @@ const renderMessage = (action, config, pull) => {
 <tr><td>requested reviewers</td><td>${JSON.stringify(pull.requested_reviewers)}</td></tr>
 <tr><td>reviewers</td><td>${JSON.stringify(pull.reviews)}</td></tr>
 <tr><td>checks</td><td>${JSON.stringify(pull.checks)}</td></tr>
-</table>`;
+</table>` + (changelog ? `#### changelog\n\n${changelog}` : '');
 }
 
 module.exports = renderMessage;

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -11,6 +11,21 @@ class Pull {
         this.checks = {};
         this.headRepoId = payload.pull_request.head.repo.id;
         this.baseRepoId = payload.pull_request.base.repo.id;
+        this.title = payload.pull_request.title;
+        this.body = payload.pull_request.body;
+    }
+
+    /**
+     * Checks for a changelog in the PR body, and returns one if found
+     */
+    parseChangelog() {
+        const CHANGELOG_HEADER = '## Changelog (the text below will be visible to users)'
+        const changelogParts = this.body.split(CHANGELOG_HEADER)
+        if (changelogParts.length > 1) {
+            const changelog = changelogParts[1]
+            return changelog
+        }
+        return null
     }
 
     /**


### PR DESCRIPTION
This pull request will add a config parameter of `changelog` that when enabled will try to parse the original pull request body for a changelog that will be used in the commit message