### PR TITLE
Skip creator when compiling reviews

### DIFF
--- a/__mocks__/pull/payload-default-expected.js
+++ b/__mocks__/pull/payload-default-expected.js
@@ -1,6 +1,7 @@
 module.exports = {
     "labels": ["foo", "bar", "ready"],
     "owner": "squalrus",
+    "creator": "squalrus",
     "pull_number": 20,
     "reviews": [],
     "branch_name": "master",

--- a/__mocks__/pull/payload-default-expected.js
+++ b/__mocks__/pull/payload-default-expected.js
@@ -1,7 +1,6 @@
 module.exports = {
     "labels": ["foo", "bar", "ready"],
     "owner": "squalrus",
-    "creator": "squalrus",
     "pull_number": 20,
     "reviews": [],
     "branch_name": "master",
@@ -10,5 +9,6 @@ module.exports = {
     "requested_reviewers": ["squalrus", "timgrove"],
     "checks": {},
     "headRepoId": 123,
-    "baseRepoId": 123
+    "baseRepoId": 123,
+    "creator": "squalrus"
 };

--- a/__mocks__/pull/payload-fork-expected.js
+++ b/__mocks__/pull/payload-fork-expected.js
@@ -9,5 +9,6 @@ module.exports = {
     "requested_reviewers": [],
     "checks": {},
     "headRepoId": 290815429,
-    "baseRepoId": 209922141
+    "baseRepoId": 209922141,
+    "creator": "aaron-trout"
 };

--- a/__mocks__/pull/payload-pull_request-expected.js
+++ b/__mocks__/pull/payload-pull_request-expected.js
@@ -9,5 +9,6 @@ module.exports = {
     "requested_reviewers": [],
     "checks": {},
     "headRepoId": 186853002,
-    "baseRepoId": 186853002
+    "baseRepoId": 186853002,
+    "creator": "Codertocat"
 };

--- a/__mocks__/pull/payload-pull_request_review-expected.js
+++ b/__mocks__/pull/payload-pull_request_review-expected.js
@@ -9,5 +9,6 @@ module.exports = {
     "requested_reviewers": [],
     "checks": {},
     "headRepoId": 186853002,
-    "baseRepoId": 186853002
+    "baseRepoId": 186853002,
+    "creator": "Codertocat"
 };

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -11,6 +11,7 @@ class Pull {
         this.checks = {};
         this.headRepoId = payload.pull_request.head.repo.id;
         this.baseRepoId = payload.pull_request.base.repo.id;
+        this.creator = payload.pull_request.user.login;
     }
 
     /**
@@ -55,18 +56,20 @@ class Pull {
                 const user = element.user.login;
                 const date = element.submitted_at;
                 const state = element.state;
-
-                if (typeof (compiled[user]) !== 'undefined') {
-                    if (date > compiled[user].date) {
+                // Creators reviews do not count since they cannot approve or reject their own PR, only comment
+                if (user !== this.creator) {
+                    if (typeof (compiled[user]) !== 'undefined') {
+                        if (date > compiled[user].date) {
+                            compiled[user] = {
+                                date: date,
+                                state: state
+                            }
+                        }
+                    } else {
                         compiled[user] = {
                             date: date,
                             state: state
                         }
-                    }
-                } else {
-                    compiled[user] = {
-                        date: date,
-                        state: state
                     }
                 }
             });


### PR DESCRIPTION
If the creator of a pull request makes a top level comment on their own PR, then the "reviews required" check will never pass.

This pull request remedies that by skipping the creator of a PR when compiling the reviews.