### PR TITLE
v0.4.9 — expand and modernize the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage/

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -10,7 +10,7 @@ The action works and its test suite passes, but the project has had no code chan
 
 | Area | Status |
 |---|---|
-| Tests | ✅ Passing (39/39) |
+| Tests | ✅ Passing (50/50), 100% statement/branch coverage across `index.js` and `lib/` (was untested for `index.js` and had several dark branches before v0.4.9) |
 | Action runtime | ✅ Fixed — now declares `node20` |
 | Dependencies | 🟠 Multiple majors behind, security advisories open |
 | CI/CD | 🟠 Split across two unmonitored systems, one on EOL Node; a `dist/` staleness check is now in place |
@@ -38,7 +38,7 @@ Prod dependencies (`npm outdated`):
 | `@actions/github` | 4.0.0 | 9.1.1 | Five majors behind. `index.js` calls REST methods directly on the octokit client (e.g. `octokit.pulls.listReviews`) rather than under `.rest.*`, which is the v4-era API shape — upgrading is a breaking change for this code, not a drop-in bump. |
 | `jest` (dev) | 26.6.3 | 30.4.2 | Four majors behind. Most of the `npm audit` noise (Babel, `ws`, etc.) comes from this dependency's transitive tree, not from anything shipped in the action itself. |
 
-`npm audit` totals: **56 vulnerabilities** (6 critical, 16 high, 33 moderate, 1 low) across 533 total dependencies (22 prod / 512 dev). The prod-facing surface is small (`@actions/core`, `@actions/github`, and their transitive deps); the bulk of the critical/high findings are in the `jest` 26 dev toolchain and would clear substantially by upgrading `jest` alone. As of [v0.4.8](https://github.com/squalrus/merge-bot/pull/81), the dev-toolchain findings no longer matter for what actually *runs*: `dist/index.js` is bundled with `@vercel/ncc`, which only pulls in `dependencies`, so `jest`/Babel/etc. never ship in the action regardless of this audit's local `npm audit` numbers. Upgrading `jest` is still worth doing for local dev hygiene, just no longer a runtime security question.
+`npm audit` totals (re-checked 2026-08-26): **54 vulnerabilities** (6 critical, 15 high, 32 moderate, 1 low) — drifted slightly from the previous count as upstream advisories shift, not from anything changed in this repo. The prod-facing surface is small (`@actions/core`, `@actions/github`, and their transitive deps); the bulk of the critical/high findings are in the `jest` 26 dev toolchain and would clear substantially by upgrading `jest` alone. As of [v0.4.8](https://github.com/squalrus/merge-bot/pull/81), the dev-toolchain findings no longer matter for what actually *runs*: `dist/index.js` is bundled with `@vercel/ncc`, which only pulls in `dependencies`, so `jest`/Babel/etc. never ship in the action regardless of this audit's local `npm audit` numbers. Upgrading `jest` is still worth doing for local dev hygiene, just no longer a runtime security question.
 
 No `.github/dependabot.yml` exists in the repo, yet Dependabot has opened PRs (#68–#75) — this is GitHub's automatic security-update behavior, not a configured `version-updates` schedule. Without a config file there's no grouping, no schedule, and no policy for how these PRs get triaged, which is consistent with 6 of them sitting open since 2021–2023.
 
@@ -94,11 +94,12 @@ Checked each against the current code (`lib/pull.js`, `lib/config.js`, `index.js
 - No linter/formatter config (no ESLint, Prettier, or `.editorconfig`) and no `engines` field in `package.json` pinning a supported Node version for local development.
 - No `SECURITY.md` or `CODEOWNERS`.
 - Issue templates exist (`bug_report.md`, `feature_request.md`) but are the unmodified GitHub defaults (still reference "Smartphone" / "Desktop" fields, irrelevant for a GitHub Action).
-- Test suite itself is in good shape: 7 suites, 39 tests, all passing, reasonable mock fixtures under `__mocks__/`.
+- ~~`index.js` (the action's entry point) had zero test coverage~~ — **fixed 2026-08-26** (v0.4.9): `__tests__/index.test.js` now mocks `@actions/core`/`@actions/github` and exercises test-mode commenting, merge + branch deletion, the fork-retains-branch path, the `canMerge=false` no-op path, and an API-failure → `core.setFailed` path. Combined with new tests closing a handful of previously-dark branches in `lib/` (an out-of-order review resubmission, a missing checks payload, `renderMessage`'s mergeable case, and `Config`'s `test`/`delete_source_branch` flags never having been asserted `true`), the suite is now 8 suites / 50 tests at 100% statement/branch/function/line coverage.
+- Test suite itself is in good shape: reasonable mock fixtures under `__mocks__/`, one file per concern.
 
 ## What's healthy / working well
 
-- Core logic (`lib/pull.js`, `lib/config.js`, `lib/message.js`) is small, readable, and fully covered by tests.
+- Core logic (`lib/pull.js`, `lib/config.js`, `lib/message.js`) and the `index.js` entry point are small, readable, and fully covered by tests (100% statement/branch coverage as of v0.4.9).
 - The "dogfooding" setup — using the action to merge its own PRs — is a nice validation loop when it's kept healthy.
 - README input/output documentation is accurate and matches `action.yml` exactly.
 - MIT license is clear and unambiguous (once `package.json` is corrected to match).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 User-visible changes, newest first. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and [semver](https://semver.org/) versioning.
 
+## [0.4.9] — 2026-08-26
+
+### Added
+- **Test coverage for `index.js`.** The action's entry point — reading the payload, fetching reviews/checks, choosing between commenting (test mode), merging, and deleting the source branch, including the fork-retains-branch and API-failure paths — had zero test coverage before this. `__tests__/index.test.js` now exercises it by mocking `@actions/core`/`@actions/github`, bringing overall coverage (statements/branches/functions/lines) to 100% across `index.js` and `lib/`. (`__tests__/index.test.js`)
+- **Coverage output ignored.** `npm test -- --coverage` writes a `coverage/` directory; added to `.gitignore` so it can't get committed by accident. (`.gitignore`)
+
+### Changed
+- **`AUDIT.md` refreshed.** Test counts and coverage status updated to reflect the above; `npm audit`'s vulnerability count re-checked and corrected (54, not 56 — normal drift in upstream advisories, not a regression). (`AUDIT.md`)
+
+### Fixed
+- **Untested branches in `lib/`.** `Pull.compileReviews`'s out-of-order-resubmission guard (an older review arriving after a newer one for the same user), `Pull.compileChecks`'s missing-payload guard, and `renderMessage`'s "mergeable" (✅) case were exercised by the existing suite only for their default outcome, leaving the other branch dark. Added targeted tests and fixtures (`__mocks__/pull/reviews-out-of-order*.js`, `__mocks__/message/message-expected-mergeable.js`) for each. (`__tests__/pull-data.test.js`, `__tests__/message.test.js`)
+- **`Config`'s `test`/`delete_source_branch` boolean mapping was never asserted `true`.** Every existing fixture passed `'false'` (or omitted the input) for these two flags, so the `getInput(...) === 'true'` mapping only had ever been checked in one direction. `__mocks__/config/core-complex.js` (and its expected output) now also flips these two. (`__mocks__/config/core-complex.js`, `__mocks__/config/config-complex.js`)
+- **Stale `package-lock.json` version.** Drifted to `0.4.7` while `package.json` had already moved to `0.4.8`; re-synced.
+
 ## [0.4.8] — 2026-08-26
 
 ### Added

--- a/__mocks__/config/config-complex.js
+++ b/__mocks__/config/config-complex.js
@@ -4,6 +4,6 @@ module.exports = {
     "merge_method": "squash",
     "review_required": false,
     "checks_enabled": true,
-    "test_mode": false,
-    "delete_source_branch": false
+    "test_mode": true,
+    "delete_source_branch": true
 };

--- a/__mocks__/config/core-complex.js
+++ b/__mocks__/config/core-complex.js
@@ -17,7 +17,10 @@ class CoreComplex {
                 return 'true';
 
             case 'test':
-                return 'false';
+                return 'true';
+
+            case 'delete_source_branch':
+                return 'true';
 
             default:
                 break;

--- a/__mocks__/message/message-expected-mergeable.js
+++ b/__mocks__/message/message-expected-mergeable.js
@@ -1,0 +1,26 @@
+module.exports = `### merge bot test mode
+
+#### overview
+
+<table>
+<tr><td>status</td><td>✅</td></tr>
+<tr><td>triggered by</td><td>foo</td></tr>
+</table>
+
+#### integration requirements
+
+<table>
+<tr><td>required label(s)</td><td>[]</td></tr>
+<tr><td>blocking label(s)</td><td>[]</td></tr>
+<tr><td>reviewers required</td><td>true</td></tr>
+<tr><td>merge method</td><td>merge</td></tr>
+</table>
+
+#### pull request details
+
+<table>
+<tr><td>labels</td><td>[\"foo\",\"bar\",\"ready\"]</td></tr>
+<tr><td>requested reviewers</td><td>[]</td></tr>
+<tr><td>reviewers</td><td>{\"squalrus\":{\"date\":\"2019-09-24T17:36:40Z\",\"state\":\"APPROVED\"},\"timgrove\":{\"date\":\"2019-09-25T05:33:37Z\",\"state\":\"APPROVED\"}}</td></tr>
+<tr><td>checks</td><td>{}</td></tr>
+</table>`;

--- a/__mocks__/pull/reviews-out-of-order-expected.js
+++ b/__mocks__/pull/reviews-out-of-order-expected.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "squalrus": {
+        "date": "2019-09-25T17:36:40Z",
+        "state": "APPROVED"
+    }
+};

--- a/__mocks__/pull/reviews-out-of-order.js
+++ b/__mocks__/pull/reviews-out-of-order.js
@@ -1,0 +1,18 @@
+module.exports = {
+    "data": [
+        {
+            "user": {
+                "login": "squalrus"
+            },
+            "submitted_at": "2019-09-25T17:36:40Z",
+            "state": "APPROVED"
+        },
+        {
+            "user": {
+                "login": "squalrus"
+            },
+            "submitted_at": "2019-09-24T05:33:37Z",
+            "state": "CHANGES_REQUESTED"
+        }
+    ]
+};

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,175 @@
+const payloadDefault = require('../__mocks__/pull/payload-default');
+const payloadFork = require('../__mocks__/pull/payload-fork');
+const reviewsNone = require('../__mocks__/pull/reviews-none');
+const checks0 = require('../__mocks__/checks/check-0');
+
+function flushPromises() {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+function makeCore(inputs) {
+    const merged = Object.assign({
+        blocking_labels: '',
+        labels: '',
+        method: 'merge',
+        reviewers: 'false',
+        checks_enabled: 'false',
+        test: 'false',
+        delete_source_branch: 'false',
+        GITHUB_TOKEN: 'test-token'
+    }, inputs);
+
+    return {
+        getInput: jest.fn((key) => merged[key]),
+        setFailed: jest.fn()
+    };
+}
+
+function makeOctokit(overrides) {
+    return Object.assign({
+        pulls: {
+            listReviews: jest.fn().mockResolvedValue(reviewsNone),
+            merge: jest.fn().mockResolvedValue({})
+        },
+        checks: {
+            listForRef: jest.fn().mockResolvedValue(checks0)
+        },
+        issues: {
+            createComment: jest.fn().mockResolvedValue({})
+        },
+        git: {
+            deleteRef: jest.fn().mockResolvedValue({})
+        }
+    }, overrides);
+}
+
+function makeGithub(payload, octokit) {
+    return {
+        context: { payload },
+        getOctokit: jest.fn(() => octokit)
+    };
+}
+
+// index.js runs immediately on require (no exported entry point), so each
+// scenario needs a fresh module registry and fresh mocks.
+async function runIndex({ inputs, payload, octokit }) {
+    jest.resetModules();
+    jest.doMock('@actions/core', () => makeCore(inputs));
+    jest.doMock('@actions/github', () => makeGithub(payload, octokit));
+
+    require('../index');
+
+    // let the chain of awaits (listReviews -> listForRef -> merge/comment -> deleteRef) settle
+    await flushPromises();
+    await flushPromises();
+
+    return {
+        core: require('@actions/core'),
+        github: require('@actions/github')
+    };
+}
+
+afterEach(() => {
+    jest.dontMock('@actions/core');
+    jest.dontMock('@actions/github');
+});
+
+test('test mode comments instead of merging', async () => {
+    const octokit = makeOctokit();
+    const { core } = await runIndex({
+        inputs: { test: 'true', labels: 'ready' },
+        payload: { action: 'synchronize', ...payloadDefault },
+        octokit
+    });
+
+    expect(octokit.issues.createComment).toHaveBeenCalledTimes(1);
+    expect(octokit.issues.createComment).toHaveBeenCalledWith(expect.objectContaining({
+        owner: 'squalrus',
+        repo: 'merge-bot',
+        issue_number: 20
+    }));
+    expect(octokit.issues.createComment.mock.calls[0][0].body).toEqual(expect.stringContaining('merge bot test mode'));
+
+    expect(octokit.pulls.merge).not.toHaveBeenCalled();
+    expect(octokit.git.deleteRef).not.toHaveBeenCalled();
+    expect(core.setFailed).not.toHaveBeenCalled();
+});
+
+test('eligible pull request is merged and its branch deleted', async () => {
+    const octokit = makeOctokit();
+    const { core } = await runIndex({
+        inputs: { labels: 'ready', method: 'squash', delete_source_branch: 'true' },
+        payload: { action: 'synchronize', ...payloadDefault },
+        octokit
+    });
+
+    expect(octokit.pulls.merge).toHaveBeenCalledWith({
+        owner: 'squalrus',
+        repo: 'merge-bot',
+        pull_number: 20,
+        merge_method: 'squash'
+    });
+    expect(octokit.git.deleteRef).toHaveBeenCalledWith({
+        owner: 'squalrus',
+        repo: 'merge-bot',
+        ref: '1234724d27c4fae27b402212182b64fda77040b5'
+    });
+    expect(octokit.issues.createComment).not.toHaveBeenCalled();
+    expect(core.setFailed).not.toHaveBeenCalled();
+});
+
+test('delete_source_branch=false merges without deleting the branch', async () => {
+    const octokit = makeOctokit();
+    await runIndex({
+        inputs: { labels: 'ready', delete_source_branch: 'false' },
+        payload: { action: 'synchronize', ...payloadDefault },
+        octokit
+    });
+
+    expect(octokit.pulls.merge).toHaveBeenCalledTimes(1);
+    expect(octokit.git.deleteRef).not.toHaveBeenCalled();
+});
+
+test('branch from a fork is retained even when delete_source_branch=true', async () => {
+    const octokit = makeOctokit();
+    await runIndex({
+        inputs: { labels: '', delete_source_branch: 'true' },
+        payload: { action: 'synchronize', ...payloadFork },
+        octokit
+    });
+
+    expect(octokit.pulls.merge).toHaveBeenCalledTimes(1);
+    expect(octokit.git.deleteRef).not.toHaveBeenCalled();
+});
+
+test('pull request missing a required label is neither merged nor commented on', async () => {
+    const octokit = makeOctokit();
+    const { core } = await runIndex({
+        inputs: { labels: 'integrate' },
+        payload: { action: 'synchronize', ...payloadDefault },
+        octokit
+    });
+
+    expect(octokit.pulls.merge).not.toHaveBeenCalled();
+    expect(octokit.git.deleteRef).not.toHaveBeenCalled();
+    expect(octokit.issues.createComment).not.toHaveBeenCalled();
+    expect(core.setFailed).not.toHaveBeenCalled();
+});
+
+test('an API failure is reported via core.setFailed instead of throwing', async () => {
+    const octokit = makeOctokit({
+        pulls: {
+            listReviews: jest.fn().mockRejectedValue(new Error('boom')),
+            merge: jest.fn().mockResolvedValue({})
+        }
+    });
+
+    const { core } = await runIndex({
+        inputs: { labels: 'ready' },
+        payload: { action: 'synchronize', ...payloadDefault },
+        octokit
+    });
+
+    expect(core.setFailed).toHaveBeenCalledWith('boom');
+    expect(octokit.pulls.merge).not.toHaveBeenCalled();
+});

--- a/__tests__/message.test.js
+++ b/__tests__/message.test.js
@@ -2,16 +2,31 @@ const Config = require('../lib/config');
 const CoreDefault = require('../__mocks__/config/core-default');
 const coreDefault = new CoreDefault();
 
+const CoreNoLabels = require('../__mocks__/config/core-no-labels');
+const coreNoLabels = new CoreNoLabels();
+
 const Pull = require('../lib/pull');
 const payloadDefault = require('../__mocks__/pull/payload-default');
+const payloadReviewers0 = require('../__mocks__/pull/payload-reviewers-0');
+const reviewsApproved = require('../__mocks__/pull/reviews-approved');
 
 const renderMessage = require('../lib/message');
 const messageExpected = require('../__mocks__/message/message-expected');
+const messageExpectedMergeable = require('../__mocks__/message/message-expected-mergeable');
 
-test('render message', () => {
+test('render message, pull cannot merge', () => {
     const config = new Config(coreDefault);
     const pull = new Pull(payloadDefault);
     const received = renderMessage('foo', config, pull);
 
     expect(received).toBe(messageExpected);
+});
+
+test('render message, pull can merge', () => {
+    const config = new Config(coreNoLabels);
+    const pull = new Pull(payloadReviewers0);
+    pull.compileReviews(reviewsApproved);
+    const received = renderMessage('foo', config, pull);
+
+    expect(received).toBe(messageExpectedMergeable);
 });

--- a/__tests__/pull-data.test.js
+++ b/__tests__/pull-data.test.js
@@ -5,6 +5,11 @@ const payloadDefault = require('../__mocks__/pull/payload-default');
 const reviewData = require('../__mocks__/pull/review-data');
 const reviewDataExpected = require('../__mocks__/pull/review-data-expected');
 
+const reviewsOutOfOrder = require('../__mocks__/pull/reviews-out-of-order');
+const reviewsOutOfOrderExpected = require('../__mocks__/pull/reviews-out-of-order-expected');
+
+const checks0 = require('../__mocks__/checks/check-0');
+
 test('parse valid reviews data', () => {
     const pull = new Pull(payloadDefault);
     pull.compileReviews(reviewData);
@@ -33,4 +38,36 @@ test('parse invalid reviews data', () => {
     const expected = JSON.stringify({});
 
     expect(received).toStrictEqual(expected);
+});
+
+test('parse reviews data with an out-of-order (older) resubmission ignored', () => {
+    const pull = new Pull(payloadDefault);
+    pull.compileReviews(reviewsOutOfOrder);
+
+    const received = JSON.stringify(pull.reviews);
+    const expected = JSON.stringify(reviewsOutOfOrderExpected);
+
+    expect(received).toStrictEqual(expected);
+});
+
+test('compile checks with undefined checks payload leaves checks unset', () => {
+    const pull = new Pull(payloadDefault);
+    pull.compileChecks(undefined);
+
+    expect(pull.checks).toStrictEqual({});
+});
+
+test('compile checks with a payload missing data leaves checks unset', () => {
+    const pull = new Pull(payloadDefault);
+    pull.compileChecks({});
+
+    expect(pull.checks).toStrictEqual({});
+});
+
+test('compile checks with valid data overwrites a previously compiled value', () => {
+    const pull = new Pull(payloadDefault);
+    pull.compileChecks(checks0);
+    pull.compileChecks(undefined);
+
+    expect(pull.checks).toStrictEqual({ total: 0, completed: 0, success: 0 });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-actions",
-  "version": "0.4.7",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-actions",
-      "version": "0.4.7",
+      "version": "0.4.9",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-actions",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- `index.js` (the action's entry point) had zero test coverage. Added `__tests__/index.test.js`, mocking `@actions/core`/`@actions/github`, covering test-mode commenting, merge + branch deletion, the fork-retains-branch path, the `canMerge=false` no-op path, and API-failure → `core.setFailed` handling.
- Closed several previously-dark branches in `lib/`: an out-of-order review resubmission in `Pull.compileReviews`, a missing checks payload in `Pull.compileChecks`, `renderMessage`'s mergeable (✅) case, and `Config`'s `test`/`delete_source_branch` flags never having been asserted `true`.
- The suite is now 8 suites / 50 tests at 100% statement/branch/function/line coverage across `index.js` and `lib/` (was 7 suites / 39 tests, with `index.js` untested).
- `.gitignore` now also ignores the `coverage/` directory `--coverage` writes.
- `AUDIT.md` refreshed: test/coverage status updated, `npm audit` vulnerability count re-checked and corrected.
- Scope note: jest stays pinned at 26.6.3 — upgrading it is intentionally left to the existing separate "Upgrade jest" backlog item rather than bundled in here.

## Test plan
- [x] `npm test` — 8 suites, 50 tests, all passing
- [x] `npm test -- --coverage` — 100% statements/branches/functions/lines across `index.js`, `lib/config.js`, `lib/pull.js`, `lib/message.js`
- [x] `npm run build` — `dist/index.js` rebuilt and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)