### PR TITLE
v0.4.19 — fix checks lookup for pull requests from forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 User-visible changes, newest first. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and [semver](https://semver.org/) versioning.
 
+## [0.4.19] — 2026-08-26
+
+### Fixed
+- **Checks lookup failed for pull requests from forks.** [index.js](index.js#L33) queried `checks.listForRef` using the head *branch name*, which only resolves within the repo that branch lives in — for a fork PR the branch lives in the fork, not the base repo, so the base repo's API 404s with "No commit found for SHA: `<branch>`". Surfaced by this repo's own dogfooding `Merge` workflow failing on PR #72 (`umegaya/merge-bot:master`). Now queries by the head commit SHA instead, which resolves regardless of which repo the branch physically lives in. (`index.js`)
+
 ## [0.4.18] — 2026-08-26
 
 ### Changed

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -155,6 +155,22 @@ test('pull request missing a required label is neither merged nor commented on',
     expect(core.setFailed).not.toHaveBeenCalled();
 });
 
+test('checks are requested by head SHA, not branch name', async () => {
+    // a branch name only resolves within the repo it lives in; for a fork
+    // PR the head branch exists on the fork, not the base repo, so
+    // checks.listForRef must be queried by the (globally resolvable) SHA
+    const octokit = makeOctokit();
+    await runIndex({
+        inputs: { labels: '' },
+        payload: { action: 'synchronize', ...payloadFork },
+        octokit
+    });
+
+    expect(octokit.rest.checks.listForRef).toHaveBeenCalledWith(expect.objectContaining({
+        ref: '05ca724d27c4fae27b402212182b64fda77040b5'
+    }));
+});
+
 test('an API failure is reported via core.setFailed instead of throwing', async () => {
     const octokit = makeOctokit({
         pulls: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -37224,7 +37224,7 @@ async function run() {
         const checks = await octokit.rest.checks.listForRef({
             owner: pull.owner,
             repo: pull.repo,
-            ref: pull.branch_name
+            ref: pull.ref
         });
 
         pull.compileReviews(reviews);

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ async function run() {
         const checks = await octokit.rest.checks.listForRef({
             owner: pull.owner,
             repo: pull.repo,
-            ref: pull.branch_name
+            ref: pull.ref
         });
 
         pull.compileReviews(reviews);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merge-bot",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merge-bot",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-bot",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
index.js queried checks.listForRef using the head branch name, which
only resolves within the repo that branch lives in. For a fork PR
the branch lives in the fork, not the base repo, so the lookup
404s. Surfaced live by this repo's own dogfooding Merge workflow
failing on PR #72 (umegaya/merge-bot:master) with "No commit found
for SHA: master". Query by the head SHA instead, which resolves
regardless of which repo the branch lives in.
