### PR TITLE
v0.5.1 — fix crash on non-pull_request events

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -6,117 +6,107 @@ This document is a point-in-time health check of the `merge-bot` repository: wha
 
 ## Summary
 
-After 5+ years without a code change, the repository had a concentrated remediation push on **2026-08-26** (v0.4.7 through v0.4.11: runtime fix, dependency upgrades, ESM migration, test coverage, `dist/` bundling, `package.json` cleanup, CI consolidation) plus CLAUDE.md/CONTRIBUTING.md/CHANGELOG.md/BACKLOG.md scaffolding — none of which had been reflected in this file's own status table until now. Every item in this audit's original "Critical items" and CI/CD sections is now fixed; what remains is long-tail PR/issue triage and lower-value hygiene items tracked in [BACKLOG.md](BACKLOG.md).
+After the 2026-08-26 remediation push (v0.4.7 through v0.4.17: runtime fix, dependency upgrades, ESM migration, test coverage, `dist/` bundling, CI consolidation, `dependabot.yml`, `CODEOWNERS`/`SECURITY.md`) covered in this audit's prior revision, the same day's second half closed out the PR/issue backlog itself: all 9 open PRs were triaged to zero, one community feature (comment-triggered re-evaluation, #72) was ported to the current codebase and merged, a real bug it surfaced along the way was fixed, and a second, more fundamental bug was discovered and documented. A third pass (v0.5.1) then fixed #77, the confirmed crash-on-every-push bug that had been the top-priority open issue, and updated [BACKLOG.md](BACKLOG.md)'s shipping checklist to require linking/attributing/closing the GitHub issue behind any shipped item going forward. **Zero PRs are open, zero stale branches remain on `origin`, and the two forks with any independent activity (`umegaya`, `comnoco`) have nothing left worth pulling in.** What remains is 7 long-standing community feature/bug issues (down from 8 — none of the rest touch code that moved this session) plus the still-open fork-merge-token limitation, all in [BACKLOG.md](BACKLOG.md).
 
 | Area | Status |
 |---|---|
-| Tests | ✅ Passing (50/50), 100% statement/branch coverage across `index.js` and `lib/` (was untested for `index.js` and had several dark branches before v0.4.9) |
-| Action runtime | ✅ Fixed — now declares `node20` |
-| Dependencies | ✅ Fixed — jest 26→30, @actions/core 1→3, @actions/github 4→9; `npm audit` 54 vulnerabilities → 0 |
-| CI/CD | ✅ Fixed — `.github/workflows/test.yml` runs `npm test` on PRs (Node 20); `azure-pipelines.yml` (EOL Node 10, actively broken) removed |
-| Open PRs | 🟠 9 open, oldest from 2019. #68 auto-closed itself 2026-08-26 as predicted below (advisory no longer applied post-v0.4.11) |
-| Open issues | 🟠 8 open, oldest from 2019; checked against current code — 7 of 8 describe gaps that still exist |
-| Repo hygiene | ✅ Fixed — `node_modules` no longer committed, now bundled via `ncc`; stale-branch picture improved (see below) |
-| Docs | 🟢 CONTRIBUTING.md, CLAUDE.md, CHANGELOG.md, BACKLOG.md all added; README solid; still no SECURITY.md |
+| Tests | ✅ Passing (54/54), 100% statement/branch coverage across `index.js` and `lib/` |
+| Action runtime | ✅ `node20` |
+| Dependencies | ✅ `npm audit`: 0 vulnerabilities; `.github/dependabot.yml` scheduling weekly scans |
+| CI/CD | ✅ `test.yml` / `build-check.yml` / `version-check.yml` / `merge-bot.yml` (now also triggers on `issue_comment`, see below) |
+| Open PRs | 🟢 **0 open** — all 9 triaged this session (7 dependabot closed as superseded, #12 closed as stale, #72 ported and merged) |
+| Open issues | 🟢 8 open on GitHub as of this writing, but #77 is fixed in v0.5.1 (this shipment) and will auto-close on merge, leaving 7 |
+| Repo hygiene | ✅ Zero stale branches on `origin` (was 8); `CODEOWNERS`, `SECURITY.md`, `dependabot.yml` all present |
+| Known issues (undocumented) | 🔴 **New:** fork PRs can't be merged via the `labeled` trigger — a GitHub platform token restriction, not a code bug. See below. |
+| Docs | 🟡 CLAUDE.md and CONTRIBUTING.md both contain **stale, incorrect** claims about the current octokit API shape and pinned dependency version — see "Documentation drift" below. |
 
-## Critical items
+## Documentation drift discovered this session
 
-1. ~~`action.yml` declares `runs.using: node12`~~ — **fixed 2026-08-26**: GitHub Actions had removed the Node 12 and Node 16 runtimes (supported runtimes are `node20`/`node24`). `action.yml` now declares `node20`; the existing test suite (39/39) was re-run and passes under Node 22, exercising the same `@actions/core`/`@actions/github` call paths. ([action.yml](action.yml))
-2. ~~`node_modules/` is committed to git~~ — **fixed 2026-08-26** ([v0.4.8](https://github.com/squalrus/merge-bot/pull/81)): the 6,630 tracked `node_modules/` files were removed in favor of a single `@vercel/ncc`-bundled `dist/index.js`, built from `index.js`/`lib/` via `npm run build`. `action.yml`'s `runs.main` now points at `dist/index.js`, a `.gitignore` was added, and [`.github/workflows/build-check.yml`](.github/workflows/build-check.yml) fails any PR where `dist/` doesn't match a fresh build, so it can't silently drift the way `package.json`'s version once did. Only production `dependencies` get bundled — `jest`/Babel/etc. (the source of most `npm audit` findings, see below) never ship in the action at all now, not just "aren't committed."
-3. ~~**`package.json` metadata is inconsistent with reality**~~ — **fixed 2026-08-26**: `license` was `"ISC"` vs. the actual MIT `LICENSE` file; `name` was the placeholder `"github-actions"`, not `merge-bot`. Both now read correctly.
-   - ~~`version: "0.2.1"` vs. latest tag `v0.4.5`~~ — **fixed 2026-08-26**: `package.json` now reads `0.4.5`, the README example pins `@v0.4.5`, and [`.github/workflows/version-check.yml`](.github/workflows/version-check.yml) fails any future tag push whose version doesn't match `package.json`, so this can't silently drift again. Release with `npm version` (see [CONTRIBUTING.md](CONTRIBUTING.md)), not a manual edit + tag.
+Both [CLAUDE.md](CLAUDE.md) ("Known constraints") and [CONTRIBUTING.md](CONTRIBUTING.md) ("Known rough edges") state that `@actions/github` is "pinned at v4" and that `index.js` calls octokit methods directly (e.g. `octokit.pulls.listReviews`) rather than under `.rest.*`. **Both claims are wrong as of the current code**: `package.json` has `@actions/github` at `^9.1.1`, and every call site in `index.js` already uses `.rest.*` (`octokit.rest.pulls.listReviews`, etc.) — this was fixed in the v0.4.11 ESM migration, which predates this session. Neither doc was updated when that migration landed, so both have been giving incorrect guidance (they'd steer a future contributor away from a `@actions/github` upgrade that's already been done, or cause confusion when the actual call shape doesn't match what's documented). Not fixed as part of this audit pass since it's out of this task's scope — worth a small dedicated doc-fix PR.
+
+## Critical items (all fixed, kept for history)
+
+1. ~~`action.yml` declares `runs.using: node12`~~ — fixed 2026-08-26. Now declares `node20`. ([action.yml](action.yml))
+2. ~~`node_modules/` is committed to git~~ — fixed 2026-08-26 ([v0.4.8](https://github.com/squalrus/merge-bot/pull/81)): bundled via `@vercel/ncc` into `dist/index.js`, `.gitignore` added, [`build-check.yml`](.github/workflows/build-check.yml) guards against drift.
+3. ~~`package.json` metadata inconsistent with reality~~ (license, name, version) — fixed 2026-08-26; [`version-check.yml`](.github/workflows/version-check.yml) now guards the version field against drift.
 
 ## Dependency / upgrade status
 
-Prod dependencies — **fixed in v0.4.11** ([released 2026-08-26](https://github.com/squalrus/merge-bot/compare/v0.4.10...v0.4.11)):
+Unchanged since the v0.4.11 upgrade (`@actions/core` 1→3, `@actions/github` 4→9, `jest` 26→30) — no dependency work happened this session beyond what dependabot's own scheduled PRs will bring going forward.
 
-| Package | Old | New | Notes |
-|---|---|---|---|
-| `@actions/core` | 1.2.6 | 3.0.1 | **Upgraded.** Old version had a moderate advisory ([GHSA-7r3h-m5j6-3q42](https://github.com/advisories/GHSA-7r3h-m5j6-3q42)). No code changes required (API stable). |
-| `@actions/github` | 4.0.0 | 9.1.1 | **Upgraded.** Octokit call sites in `index.js` updated from direct method calls (e.g. `octokit.pulls.listReviews`) to `.rest.*` namespace (v5+/v9 requires this shape). |
-| `jest` (dev) | 26.6.3 | 30.4.2 | **Upgraded.** Bulk of `npm audit` findings (Babel, `ws`, `jsdom`, etc.) resolved. Jest 27+ config changes applied (test environment defaults, etc.). |
-| `@vercel/ncc` (dev) | 0.38.4 | 0.45.0 | **Upgraded** to support ESM bundling (required because prod dependencies are now ESM-only). |
+`npm audit` (re-checked 2026-08-26): **0 vulnerabilities**.
 
-**ESM migration:** `@actions/core@3` and `@actions/github@9` export only ESM (`"type": "module"`), no CommonJS fallback. The entire codebase (`index.js`, `lib/`, tests, mocks) was converted from `require()`/`module.exports` to `import`/`export` to match. `package.json` declares `"type": "module"`. Jest runs with `--experimental-vm-modules` to support ESM test modules. This is a breaking change for any direct consumers of the source code (the npm package is not published; consumers import the bundled action via GitHub Actions only).
-
-`npm audit` totals (re-checked 2026-08-26): **0 vulnerabilities** — down from 54. As of v0.4.8, dev-dependency advisories don't affect runtime anyway (`dist/index.js` bundles only production dependencies via `@vercel/ncc`), but clearing the local `npm audit` score improves CI/CD signaling and local dev hygiene.
-
-Dependabot security-alert PRs (#64, #69–#75, open since 2021–2023) — #68 already auto-closed on 2026-08-26 as GitHub re-scanned the default branch post-v0.4.11 and found its advisory no longer applied; expect the rest to follow the same way over time, though they can also just be closed manually now. No `.github/dependabot.yml` exists (yet), so no version-updates schedule; the backlog has an item to add one.
+**Dependabot PRs — resolved 2026-08-26.** The 7 long-open dependabot PRs (#64, #69–#71, #73–#75) were all closed as superseded: each target dependency was already at or past the proposed version, or no longer in the tree at all, following the v0.4.11 upgrade. [`.github/dependabot.yml`](.github/dependabot.yml) (added in v0.4.17) now schedules weekly `npm` scans with dev-dependency bumps grouped into a single PR, so future dependency PRs should arrive in scheduled batches instead of drifting open for years.
 
 ## CI/CD pipelines
 
-**Fixed 2026-08-26:** `azure-pipelines.yml` has been deleted and `.github/workflows/test.yml` added (`npm ci && npm test` on `actions/setup-node@v4` with `node-version: 20`, triggered on PRs to `main`), matching the pattern already used by `build-check.yml`. Verified locally: 50/50 tests pass under Node 20. A status badge was added to the README. This closes the backlog item "Consolidate CI onto a single GitHub Actions workflow."
+Unchanged from the prior audit's fixed state (`test.yml`, `build-check.yml`, `version-check.yml`, Azure retired), plus one addition:
 
-Four systems now exist on GitHub Actions (no more Azure dependency):
+- **`.github/workflows/merge-bot.yml`** now also triggers on `issue_comment: [created]` (added in v0.4.18), gated by `if: github.event_name != 'issue_comment' || github.event.issue.pull_request` so it's a no-op for comments on plain issues. This exists to support #72's comment-triggered re-evaluation (see below) — useful for retrying after a transient "Base branch was modified" failure by commenting on the PR instead of re-labeling it.
 
-- **`.github/workflows/test.yml`** *(new)* — runs `npm test` on PRs to `main`, Node 20. This is the CI test signal that was previously missing entirely (the old Azure pipeline was the only thing running `npm test`, and it was broken — see history below).
-- **`.github/workflows/merge-bot.yml`** — the action *using itself* (`uses: squalrus/merge-bot@main`) to manage this repo's own PRs. Runs with `reviewers: false` and `checks_enabled: false`, meaning label alone (`ready`) is sufficient to auto-merge, and `delete_source_branch: false` — this repo's own bot-merged PRs do **not** get their branches deleted, which is one contributor to the stale-branch count below (though not the dominant one currently).
-- **`.github/workflows/build-check.yml`** — added in [v0.4.8](https://github.com/squalrus/merge-bot/pull/81). Rebuilds `dist/` on every PR to `main` and fails if it doesn't match a fresh `npm run build`.
-- **`.github/workflows/version-check.yml`** — added alongside the `package.json` version fix. Fails a tag push if it doesn't match `package.json`'s version.
+## Open pull requests (0)
 
-**Retired:** `azure-pipelines.yml` (ran `npm install -g jest --save-dev && npm install && npm test` on **Node 10.x**, EOL April 2021, triggered on PRs to `master`). It was actively broken as of 2026-08-26: the global `npm install -g jest` step pulled Jest 30.x, whose `jest-resolve` dependency (`unrs-resolver`, a native module) fails its postinstall script under Node 10.x. No fix was applied — it was deleted outright, since `test.yml` supersedes it and the Node 10.x pin was obsolete regardless.
+**All 9 triaged and closed out 2026-08-26** — none remain open.
 
-## Open pull requests (9)
+| # | Title | Resolution |
+|---|---|---|
+| #64, #69, #70, #71, #73, #74, #75 | dependabot dependency bumps | Closed as superseded — target versions already met or packages no longer in the tree post-v0.4.11 |
+| #12 | Resubmit reviews after push (squalrus, 2019) | Closed as stale — branch predated the ESM/`octokit.rest.*` rewrite and couldn't be rebased cleanly. Its idea (re-request review from prior approvers on push) is folded into the [Remove label / re-request review on commit](BACKLOG.md#remove-label--re-request-review-on-commit) backlog item as prior art |
+| #72 | Make the action work with pull request comment event (umegaya, 2022) | Ported to the current ESM/`octokit.rest.*` codebase (original author kept as commit co-author), reviewed, CI verified green, **merged** as part of v0.5.0. Along the way, testing it live surfaced and led to fixing a real bug (below) and discovering a second, more fundamental one (also below) |
 
-**Status update (2026-08-26):** #81 (the `node_modules`/`dist` bundling fix) has since merged as v0.4.8, and #68 ("Bump minimist") auto-closed itself today, exactly as this audit previously predicted — its advisory no longer applies now that dev dependencies don't ship in `dist/`. Re-checked live via `gh pr list`; 9 remain open, table below reflects current state.
+**Bug found and fixed while validating #72's checks:** [index.js](index.js#L33) queried `checks.listForRef` using the head *branch name*, which only resolves within the repo that branch lives in — for a fork PR (like #72) the branch lives in the fork, not the base repo, so the lookup 404'd with "No commit found for SHA: `<branch>`". Surfaced live by this repo's own dogfooding `Merge` workflow failing on #72. Fixed in v0.4.19 to query by the head SHA instead, which resolves regardless of which repo the branch physically lives in.
 
-| # | Title | Author | Opened | Mergeable | Notes |
-|---|---|---|---|---|---|
-| [#75](https://github.com/squalrus/merge-bot/pull/75) | Bump json5 from 2.2.0 to 2.2.3 | dependabot | 2023-01-07 | ❌ CONFLICTING | dev dep |
-| [#74](https://github.com/squalrus/merge-bot/pull/74) | Bump qs from 6.5.2 to 6.5.3 | dependabot | 2022-12-10 | ❌ CONFLICTING | dev dep |
-| [#73](https://github.com/squalrus/merge-bot/pull/73) | Bump decode-uri-component from 0.2.0 to 0.2.2 | dependabot | 2022-12-04 | ❌ CONFLICTING | dev dep |
-| [#72](https://github.com/squalrus/merge-bot/pull/72) | Make the action work with pull request comment event | umegaya (community) | 2022-11-04 | ⚠️ UNKNOWN | Real feature contribution, unlabeled, never triaged |
-| [#71](https://github.com/squalrus/merge-bot/pull/71) | Bump @actions/core from 1.2.6 to 1.9.1 | dependabot | 2022-08-18 | ❌ CONFLICTING | Superseded by going straight to 3.0.1 |
-| [#70](https://github.com/squalrus/merge-bot/pull/70) | Bump node-fetch from 2.6.1 to 2.6.7 | dependabot | 2022-06-25 | ❌ CONFLICTING | dev dep |
-| [#69](https://github.com/squalrus/merge-bot/pull/69) | Bump jsdom from 16.4.0 to 16.7.0 | dependabot | 2022-06-23 | ❌ CONFLICTING | dev dep, superseded by the jest 30 upgrade |
-| [#64](https://github.com/squalrus/merge-bot/pull/64) | Bump ansi-regex from 5.0.0 to 5.0.1 | dependabot | 2021-11-02 | ❌ CONFLICTING | dev dep |
-| [#12](https://github.com/squalrus/merge-bot/pull/12) | Resubmit reviews after push | squalrus (you) | 2019-10-04 | ⚠️ UNKNOWN | Your own 6-year-old branch, needs a decision: land or close |
+**Bug found and NOT yet fixed — fork PRs structurally can't be merged via the `labeled` trigger:** after the above fix, labeling #72 to trigger a merge got as far as `canMerge() === true` and then failed at the actual `octokit.rest.pulls.merge` call with "Resource not accessible by integration". This is a GitHub platform restriction, not a merge-bot bug: for `pull_request`-family events (`labeled`, `synchronize`, etc.) triggered by a PR from a forked repository, `GITHUB_TOKEN` is **always** read-only, regardless of the repo's own workflow-permissions default (confirmed this repo's default is "write" — doesn't matter here). #72 had to be merged manually via `gh pr merge` to work around it. This means **no fork-originated PR can be auto-merged by this bot today, regardless of labels** — likely relevant often, given 12 forks exist. Tracked as [Fork PRs can't be auto-merged via the labeled trigger](BACKLOG.md#fork-prs-cant-be-auto-merged-via-the-labeled-trigger) in the backlog; the fix is switching `merge-bot.yml`'s `pull_request:` trigger to `pull_request_target:`, which is safe here specifically because the workflow never checks out or executes the fork's code.
 
-**Recommendation:** all 7 remaining dependabot PRs now show CONFLICTING (they've drifted further as `package.json`/`package-lock.json` changed underneath them this session) and are individually superseded by the v0.4.11 `jest`/`@actions/*` upgrade — close them rather than attempting to rebase and merge piecemeal. #72 is the one PR that needs a real human decision (feature review), and #12 needs an explicit close-or-rebase call since it's your own stale work. This matches the backlog item "Triage the 7 open pull requests" (written when #68 was still counted; it's now 6 dependabot PRs plus #64, which the backlog text omitted).
+## Fork survey (2026-08-26)
 
-## Open issues (8)
+Checked the two forks with any independent activity beyond a stock fork:
 
-Checked each against the current code (`lib/pull.js`, `lib/config.js`, `index.js`), not just left as reported — since none of it has changed since 2021, most are still exactly as described.
+- **[umegaya/merge-bot](https://github.com/umegaya/merge-bot)** — nothing left to capture; its only unique work was #72, now merged.
+- **[comnoco/merge-bot](https://github.com/comnoco/merge-bot)** — diverged independently in 2022–2023 and did its own Node 12→16→20 runtime upgrade and dependency bumps, but every bit of it is superseded by this repo's own history (already on `node20`; their three open dependabot branches propose *older* versions than what's already in `package.json`). Never opened a PR against this repo, so none of it was ever proposed here. Nothing worth backporting.
 
-| # | Title | Author | Opened | Still valid? | Notes |
-|---|---|---|---|---|---|
-| [#77](https://github.com/squalrus/merge-bot/issues/77) | Error: Cannot read properties of undefined (reading 'labels') | chickenandpork (community) | 2023-08-24 | ✅ Confirmed, reproducible | [Pull's constructor](lib/pull.js#L3) does `payload.pull_request.labels.map(...)` unconditionally. The reporter's workflow triggers on `push` in addition to `pull_request`; a `push` event payload has no `pull_request` object at all, so this throws on every push. `index.js` never checks that `github.context.payload.pull_request` exists before constructing `Pull`. |
-| [#59](https://github.com/squalrus/merge-bot/issues/59) | Time based allow/block of merges | alper (community) | 2021-06-15 | ✅ Still unimplemented | [lib/config.js](lib/config.js) has no time-window input, and nothing in `Pull.canMerge` consults a clock. Net-new feature — no work started. |
-| [#56](https://github.com/squalrus/merge-bot/issues/56) | Allow merges even if the base branch changes | RevolutionTech (community) | 2021-04-28 | ✅ Still unimplemented | [index.js](index.js#L57) calls `octokit.pulls.merge` with no retry logic; a "base branch was modified" failure from a concurrent merge just bubbles up to `core.setFailed`. Nothing tolerates or retries on base drift. |
-| [#37](https://github.com/squalrus/merge-bot/issues/37) | Not detecting reviews? | aaron-trout (community) | 2020-09-03 | 🟡 Partially explained | [Pull's constructor](lib/pull.js#L10) reads only `payload.pull_request.requested_reviewers` — it never looks at `requested_teams`. A CODEOWNERS rule assigning a *team* (as in the report) won't show up there. Combined with no re-trigger on review submission (see #22), a stale payload at merge time is the likely proximate cause, but the missing `requested_teams` handling is a real, still-current gap in its own right. |
-| [#22](https://github.com/squalrus/merge-bot/issues/22) | Re-trigger Action when checks complete | squalrus (you) | 2020-01-26 | ✅ Still true | The action runs once per triggering event and never requeues itself; [.github/workflows/merge-bot.yml](.github/workflows/merge-bot.yml) doesn't listen for `check_suite`/`workflow_run`/`pull_request_review` completion, so a check finishing after the bot's last run won't cause a re-evaluation. |
-| [#14](https://github.com/squalrus/merge-bot/issues/14) | follow the configured required review count | Evanion (community) | 2019-12-20 | ✅ Still true | [lib/config.js:6](lib/config.js#L6) `review_required` is a plain boolean; [Pull.isReviewComplete](lib/pull.js#L20) requires 100% of `requested_reviewers` to approve, with no concept of a numeric threshold or the repo's actual branch-protection required-approval count. |
-| [#13](https://github.com/squalrus/merge-bot/issues/13) | Update from base branch before merging. | Evanion (community) | 2019-12-20 | ✅ Still true | No call to `pulls.updateBranch` (or equivalent) anywhere in the codebase — the bot never brings a PR branch up to date with base before merging. |
-| [#7](https://github.com/squalrus/merge-bot/issues/7) | Feature: on commit, remove label(?) or Re-request review(?) | squalrus (you) | 2019-09-27 | ✅ Still true | No label-removal or re-review-request logic exists anywhere in `index.js`/`lib/`. |
+## Open issues (7, was 8)
 
-**Recommendation:** #77 is the one that should be prioritized above the others — it's a confirmed crash-on-every-push bug affecting a real user today, not a feature request, and the fix (guard on `payload.pull_request` before constructing `Pull`, in [index.js](index.js#L16)) is small and self-contained. The rest are long-standing feature requests that are all still genuinely open against today's code; worth a pass to confirm which are still wanted versus safe to close as stale, but none can be closed as "already fixed."
+Re-checked against current code (`lib/pull.js`, `lib/config.js`, `index.js`). #77 is fixed as of v0.5.1 (this shipment) and will close automatically on merge (`Fixes #77` in the PR body) — the other 7 are unchanged, since none of this session's code changes touched the areas they report on.
+
+| # | Title | Author | Opened | Still valid? |
+|---|---|---|---|---|
+| ~~[#77](https://github.com/squalrus/merge-bot/issues/77)~~ | Error: Cannot read properties of undefined (reading 'labels') | chickenandpork (community) | 2023-08-24 | ✅ **Fixed in v0.5.1** — `index.js` now guards on `payload.pull_request` existing before constructing `Pull`, no-oping cleanly on non-PR events (e.g. `push`) instead of crashing |
+| [#59](https://github.com/squalrus/merge-bot/issues/59) | Time based allow/block of merges | alper (community) | 2021-06-15 | ✅ Still unimplemented |
+| [#56](https://github.com/squalrus/merge-bot/issues/56) | Allow merges even if the base branch changes | RevolutionTech (community) | 2021-04-28 | ✅ Still unimplemented |
+| [#37](https://github.com/squalrus/merge-bot/issues/37) | Not detecting reviews? | aaron-trout (community) | 2020-09-03 | 🟡 Partially explained — missing `requested_teams` handling |
+| [#22](https://github.com/squalrus/merge-bot/issues/22) | Re-trigger Action when checks complete | squalrus (you) | 2020-01-26 | ✅ Still true |
+| [#14](https://github.com/squalrus/merge-bot/issues/14) | follow the configured required review count | Evanion (community) | 2019-12-20 | ✅ Still true |
+| [#13](https://github.com/squalrus/merge-bot/issues/13) | Update from base branch before merging. | Evanion (community) | 2019-12-20 | ✅ Still true |
+| [#7](https://github.com/squalrus/merge-bot/issues/7) | Feature: on commit, remove label(?) or Re-request review(?) | squalrus (you) | 2019-09-27 | ✅ Still true |
+
+**Recommendation:** with #77 shipped, the fork-merge-token limitation (below) is now the single highest-priority item — it structurally blocks every external contributor's PR from being auto-merged, and the fix is small and well-understood (`pull_request` → `pull_request_target` in `merge-bot.yml`).
 
 ## Repository hygiene observations
 
-- **Stale-branch picture re-checked 2026-08-26** (`git fetch --prune` + `git branch -r --no-merged`): the "22 stale branches" figure was stale itself — it included local tracking refs for branches already deleted on GitHub. The real current count on `origin` is 7 (`dependabot/npm_and_yarn/*`) + 1 (`resubmit-reviews`), and **every one of them backs a currently-open PR** (the 7 dependabot PRs plus #12) — so by the backlog item's own definition ("no corresponding open PR"), there are zero prunable branches on `origin` right now. Pruning is blocked on the PR triage above, not a standalone task; revisit the branch list once those PRs are closed. (The `aaron-trout/*` branches seen in a naive `git branch -r` are on a separate fork remote added to this local clone for reviewing #72 — not part of `squalrus/merge-bot` and not this repo's to prune.) Separately, `.github/workflows/merge-bot.yml` sets `delete_source_branch: false`, so this repo's own bot-merged PRs (labeled `ready`) don't get branch cleanup for free — worth flipping to `true` if branch buildup becomes a recurring nuisance.
-- ~~No `.gitignore` at all~~ — **fixed 2026-08-26**: added alongside the `node_modules` removal ([v0.4.8](https://github.com/squalrus/merge-bot/pull/81)); currently just ignores `node_modules/`.
-- ~~No linter/formatter config (no ESLint, Prettier, or `.editorconfig`) and no `engines` field in `package.json` pinning a supported Node version for local development~~ — **fixed 2026-08-26** (v0.4.14): added `eslint.config.js` (ESLint 9.x, pinned to the maintenance line since 10.x needs a newer Node patch than some dev machines have) enforcing the documented 4-space-indent/semicolon style, plus `.editorconfig` and `engines.node: ">=20"` matching `action.yml`'s runtime.
-- No `SECURITY.md` or `CODEOWNERS`.
-- Issue templates exist (`bug_report.md`, `feature_request.md`) but are the unmodified GitHub defaults (still reference "Smartphone" / "Desktop" fields, irrelevant for a GitHub Action).
-- ~~`index.js` (the action's entry point) had zero test coverage~~ — **fixed 2026-08-26** (v0.4.9): `__tests__/index.test.js` now mocks `@actions/core`/`@actions/github` and exercises test-mode commenting, merge + branch deletion, the fork-retains-branch path, the `canMerge=false` no-op path, and an API-failure → `core.setFailed` path. Combined with new tests closing a handful of previously-dark branches in `lib/` (an out-of-order review resubmission, a missing checks payload, `renderMessage`'s mergeable case, and `Config`'s `test`/`delete_source_branch` flags never having been asserted `true`), the suite is now 8 suites / 50 tests at 100% statement/branch/function/line coverage.
-- Test suite itself is in good shape: reasonable mock fixtures under `__mocks__/`, one file per concern.
+- **Zero stale branches on `origin`** (re-checked 2026-08-26, was 8 in the prior audit): all 7 dependabot branches were auto-deleted by GitHub when their PRs closed; the one remaining (`resubmit-reviews`, backing #12) was manually deleted after that PR closed. `origin` now has exactly one branch: `main`. `.github/workflows/merge-bot.yml` still sets `delete_source_branch: false` for this repo's own bot-merged PRs — worth flipping to `true` if branch buildup becomes a recurring nuisance again.
+- ~~No `SECURITY.md` or `CODEOWNERS`~~ — **fixed** (v0.4.15, predates this session but wasn't reflected in the prior audit's status table): both now exist.
+- ~~No `.github/dependabot.yml`~~ — **fixed** (v0.4.17, predates this session): weekly `npm` scans, dev-dependency bumps grouped.
+- **New this session:** CLAUDE.md and CONTRIBUTING.md both contain stale/incorrect claims about the octokit API shape and `@actions/github` version — see "Documentation drift" above.
+- Issue templates exist (`bug_report.md`, `feature_request.md`); `bug_report.md` was tidied for a GitHub Action's actual fields in v0.4.13, `feature_request.md` is still the unmodified GitHub default.
+- Test suite: 8 suites / 54 tests, 100% statement/branch/function/line coverage (was 50 tests at the prior audit; +4 from this session's `issue_comment` handling, fork-SHA regression test, #72's own coverage, and #77's non-PR-payload regression test).
+- **New this session:** [BACKLOG.md](BACKLOG.md)'s "Shipping a backlog item" checklist now requires, for any item traced to a GitHub issue: linking the issue and crediting the reporter in the CHANGELOG entry, including `Fixes #<n>`/`Closes #<n>` in the shipping PR body, and verifying post-merge that the issue actually auto-closed.
 
 ## What's healthy / working well
 
-- Core logic (`lib/pull.js`, `lib/config.js`, `lib/message.js`) and the `index.js` entry point are small, readable, and fully covered by tests (100% statement/branch coverage as of v0.4.9).
-- The "dogfooding" setup — using the action to merge its own PRs — is a nice validation loop when it's kept healthy.
-- README input/output documentation is accurate and matches `action.yml` exactly.
-- MIT license is clear and unambiguous, and `package.json` now correctly reflects it.
+- Core logic (`lib/pull.js`, `lib/config.js`, `lib/message.js`) and `index.js` are small, readable, and fully covered by tests.
+- The "dogfooding" setup — using the action to merge its own PRs — caught two real bugs this session (the fork checks-lookup 404, and the fork merge-token restriction) that would otherwise have shipped silently and only surfaced when an external contributor's PR failed to merge.
+- README input/output documentation is accurate and matches `action.yml`.
+- Maintainer-can-modify was used successfully to update a stale external contribution (#72) in place while preserving the original author's commit and crediting them as co-author — worth remembering as the pattern for future stale-but-valuable community PRs.
 
 ## Suggested triage order
 
-1. ~~Fix `action.yml` runtime (`node12` → `node20`)~~ — done 2026-08-26.
-2. ~~Reconcile remaining `package.json` fields (name, license) with reality~~ — done 2026-08-26; version was already fixed and guarded.
-3. ~~Replace committed `node_modules` with an `ncc`-bundled `dist/` and a `.gitignore`~~ — done 2026-08-26 ([v0.4.8](https://github.com/squalrus/merge-bot/pull/81)).
-4. ~~Consolidate CI onto one GitHub Actions workflow; decide the fate of `azure-pipelines.yml`~~ — done 2026-08-26: `.github/workflows/test.yml` added, `azure-pipelines.yml` removed.
-5. ~~Upgrade `jest` to clear the bulk of `npm audit` findings; upgrade `@actions/core`/`@actions/github` deliberately~~ — done 2026-08-26 (v0.4.11).
-6. Triage the 9 remaining open PRs (close the 7 superseded dependency bumps, review #72's feature contribution on its merits, resolve #12 close-or-rebase).
-7. Add `dependabot.yml` so future dependency PRs are scheduled/grouped instead of arriving ad hoc.
-8. Revisit stale-branch pruning once #6 lands — currently zero `origin` branches lack an open PR, so there's nothing to prune yet.
+1. ~~Fix `action.yml` runtime, `node_modules`, `package.json` metadata, CI consolidation, dependency upgrades~~ — done (prior session, v0.4.7–v0.4.11).
+2. ~~Triage the 9 open PRs~~ — done 2026-08-26 (this session): 7 dependabot closed, #12 closed, #72 ported and merged.
+3. ~~Prune stale branches~~ — done 2026-08-26 (this session): zero remain on `origin`.
+4. ~~Fix #77 (crash on non-PR events)~~ — done 2026-08-26, shipped as v0.5.1.
+5. Fix the fork-merge-token limitation (`pull_request` → `pull_request_target` in `merge-bot.yml`) — blocks the bot's core use case for any external contributor. Highest-value remaining item.
+6. Fix the CLAUDE.md/CONTRIBUTING.md stale-claims doc drift — small, prevents a future contributor from being misled.
+7. Work through the remaining community feature requests (#7, #13, #14, #22, #37, #56, #59) at your own pace — none are urgent, all are still genuinely wanted as far as this audit can tell.
 
 These are tracked as individual items in [BACKLOG.md](BACKLOG.md).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -5,12 +5,13 @@ Tracks future features, improvements, and known bugs. Items here are not committ
 ## Shipping a backlog item
 
 1. Branch off `main` named for the target version (`vX.Y.Z`). Never commit directly to `main`.
-2. Move the entry to CHANGELOG.md with a version block (date, classification, user-facing summary). Remove it from here.
+2. Move the entry to CHANGELOG.md with a version block (date, classification, user-facing summary). Remove it from here. If the item traces to a GitHub issue, link it (`#<n>`) and credit the reporter by `@username` in the entry — most "Why" sections already have both, so this is usually just carrying them over.
 3. Update docs where reality changed (README, CONTRIBUTING, etc.).
 4. Pick the version by semver: feature → minor; bug / improvement / cleanup → patch; breaking → major.
 5. Bump the version in whichever location CLAUDE.md documents (package.json, VERSION file, or CHANGELOG.md only).
 6. Run the build as the correctness gate.
-7. Commit and push the branch, then open a PR with `gh pr create`. Requires [GitHub CLI](https://cli.github.com) installed and authenticated (`gh auth login`).
+7. Commit and push the branch, then open a PR with `gh pr create`. If the item traces to a GitHub issue, include `Fixes #<n>` (or `Closes #<n>`) in the PR body so merging auto-closes it — GitHub links the issue to the PR either way. Requires [GitHub CLI](https://cli.github.com) installed and authenticated (`gh auth login`).
+8. After merging, verify the linked issue actually closed (auto-close only fires if the PR merged into the repo's *default* branch — confirm `main` is set as default, or close manually with `gh issue close <n> --comment "Fixed in <PR link>"` if it didn't).
 
 ## Suggested execution order
 
@@ -37,7 +38,7 @@ No open improvements.
 
 | Title | Effort | Value |
 |---|---|---|
-| [Crash on non-PR events (missing pull_request payload)](#crash-on-non-pr-events-missing-pull_request-payload) | S | H |
+| [Fork PRs can't be auto-merged via the labeled trigger](#fork-prs-cant-be-auto-merged-via-the-labeled-trigger) | S | H |
 | [Not detecting team-requested reviews](#not-detecting-team-requested-reviews) | S | M |
 
 ### Limitations
@@ -53,10 +54,10 @@ No open limitations.
 **Why** — Consumers currently either pin an exact tag (`@v0.4.5`) or float on `@main`. A moving major tag (e.g. `v0`) lets them pin `squalrus/merge-bot@v0` and pick up patch/minor releases automatically without tracking every release — the common convention for GitHub Actions (see `actions/checkout@v4`, etc.).
 **Notes:** On release, after `npm version` creates the exact tag, force-move the major tag to point at the new commit and push it: `git tag -f v0 <new-tag> && git push origin v0 --force`. Add this as a step in [CONTRIBUTING.md](CONTRIBUTING.md)'s release process, ideally automated in a release workflow rather than manual. Consider updating the README's example usage to recommend pinning the major tag instead of an exact version once this exists.
 
-### Crash on non-PR events (missing pull_request payload)
+### Fork PRs can't be auto-merged via the labeled trigger
 **Type:** Bug
-**Why** — Confirmed reproducible crash reported in [#77](https://github.com/squalrus/merge-bot/issues/77): `Pull`'s constructor ([lib/pull.js](lib/pull.js#L3)) does `payload.pull_request.labels.map(...)` unconditionally. A workflow triggered on `push` (in addition to `pull_request`, as the reporter's is) delivers a payload with no `pull_request` object at all, so this throws on every push. Real user impact today, not a hypothetical — flagged by the audit as the single highest-priority item outstanding.
-**Notes:** Guard on `github.context.payload.pull_request` existing before constructing `Pull` in [index.js](index.js#L16); no-op cleanly on non-PR events instead of crashing. Small, self-contained fix.
+**Why** — Discovered live 2026-08-26: labeling PR #72 (head `umegaya/merge-bot:master`, a fork) to trigger a merge failed with "Resource not accessible by integration" at the `octokit.rest.pulls.merge` call, even though `canMerge()` correctly evaluated `true` and reads (reviews, checks) succeeded. Root cause is a GitHub platform restriction, not a merge-bot bug: for `pull_request`-family events (`labeled`, `synchronize`, etc.) triggered by a PR from a forked repository, `GITHUB_TOKEN` is always read-only, regardless of the repo's own default workflow-permissions setting (confirmed `squalrus/merge-bot`'s default is "write" — doesn't matter for fork-triggered `pull_request` events). So no fork-originated PR can be merged via the label trigger today, structurally, no matter what config is set — had to merge #72 manually via `gh pr merge` to work around it. Blocks the bot's core use case for any external contributor PR, which is presumably common for a 12-fork open source project.
+**Notes:** Change `.github/workflows/merge-bot.yml`'s `pull_request:` trigger to `pull_request_target:`, which runs with the base repo's full-permission token even for fork PRs. Safe here specifically because the workflow never checks out or executes the fork's code — no `actions/checkout` step exists; the "Integration check" step only invokes `squalrus/merge-bot@main` (trusted code from the base repo) against webhook payload data, so there's no path for untrusted fork code to run with the elevated token.
 
 ### Not detecting team-requested reviews
 **Type:** Bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 User-visible changes, newest first. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and [semver](https://semver.org/) versioning.
 
+## [0.5.1] — 2026-08-26
+
+### Fixed
+- **Crash on events with no `pull_request` in the payload.** Reported in [#77](https://github.com/squalrus/merge-bot/issues/77) by [@chickenandpork](https://github.com/chickenandpork). `Pull`'s constructor read `payload.pull_request.labels` unconditionally; a workflow triggered on `push` (in addition to `pull_request`, as the reporter's was) delivers a payload with no `pull_request` object at all, crashing on every push. `index.js` now guards on `payload.pull_request` existing before constructing `Pull`, logging and no-oping cleanly on non-PR events instead. (`index.js`, `__tests__/index.test.js`)
+
+### Changed
+- **BACKLOG.md's shipping checklist now covers GitHub issues end-to-end.** For any shipped item traced to a GitHub issue: the CHANGELOG entry must link the issue and credit the reporter, the shipping PR body must include `Fixes #<n>`/`Closes #<n>` so merging auto-closes it, and a post-merge step verifies the close actually happened. (`BACKLOG.md`)
+- **AUDIT.md refreshed** to reflect the completed PR/issue triage, the #72 merge and the two bugs it surfaced, the zero-stale-branch state, the fork-merge-token limitation, and stale claims found in CLAUDE.md/CONTRIBUTING.md about the octokit API shape. (`AUDIT.md`)
+
 ## [0.5.0] — 2026-08-26
 
 ### Added

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -147,7 +147,20 @@ test('comment on a plain issue does not attempt to fetch a pull request', async 
 
     expect(octokit.rest.pulls.get).not.toHaveBeenCalled();
     expect(octokit.rest.pulls.merge).not.toHaveBeenCalled();
-    expect(core.setFailed).toHaveBeenCalled();
+    expect(core.setFailed).not.toHaveBeenCalled();
+});
+
+test('a payload with no pull_request at all (e.g. a push event) is a clean no-op', async () => {
+    const octokit = makeOctokit();
+    const { core } = await runIndex({
+        inputs: { labels: 'ready' },
+        payload: { action: null, repository: payloadDefault.repository },
+        octokit
+    });
+
+    expect(octokit.rest.pulls.listReviews).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.merge).not.toHaveBeenCalled();
+    expect(core.setFailed).not.toHaveBeenCalled();
 });
 
 test('delete_source_branch=false merges without deleting the branch', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -37224,6 +37224,11 @@ async function run() {
             payload.pull_request = response.data;
         }
 
+        if (!payload.pull_request) {
+            console.log(`[info] no pull_request in payload, nothing to do`);
+            return;
+        }
+
         const pull = new lib_pull(payload);
         console.log(`[data] pull (payload): ${JSON.stringify(pull)}`);
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,11 @@ async function run() {
             payload.pull_request = response.data;
         }
 
+        if (!payload.pull_request) {
+            console.log(`[info] no pull_request in payload, nothing to do`);
+            return;
+        }
+
         const pull = new Pull(payload);
         console.log(`[data] pull (payload): ${JSON.stringify(pull)}`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "merge-bot",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "merge-bot",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-bot",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Fixes #77

`Pull`'s constructor read `payload.pull_request.labels` unconditionally. A workflow triggered on `push` (in addition to `pull_request`, as the reporter's is) delivers a payload with no `pull_request` object at all, crashing on every push. `index.js` now guards on `payload.pull_request` existing before constructing `Pull`, logging and no-oping cleanly on non-PR events instead of throwing.

Also:
- AUDIT.md refreshed to reflect the #77 fix, the completed PR/issue triage, and the fork-merge-token limitation as the new top-priority item.
- BACKLOG.md's shipping checklist now requires linking/attributing/closing a referenced GitHub issue as part of shipping any item that traces to one.

Reported by @chickenandpork.