### PR TITLE
v0.5.7 - fix greedy regex that mangled v0.5.6's own release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 User-visible changes, newest first. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and [semver](https://semver.org/) versioning.
 
+## [0.5.7] — 2026-08-27
+
+### Fixed
+- **v0.5.6's own release notes came out truncated and mangled.** The bold-lead extraction added in v0.5.6 used a greedy `(.*)` that matched through to the *last* occurrence of a closing bold marker in the CHANGELOG bullet, not the first — and v0.5.6's own CHANGELOG entry happened to reference a second bold span later in its text, so its generated release notes cut off mid-sentence. `scripts/tag-and-release.sh` now matches non-asterisk characters only, so it always stops at the first closing marker regardless of what appears later in the bullet. The live v0.5.6 release notes were corrected by hand to match. (`scripts/tag-and-release.sh`)
+
 ## [0.5.6] — 2026-08-27
 
 ### Changed
-- **GitHub Release notes are now a short bullet list, not the full CHANGELOG entry.** Every release since v0.4.6 had pasted its entire CHANGELOG.md section (bold headers, rationale, file lists) verbatim as the GitHub Release notes — unlike the short, scannable one-liners releases had before v0.4.6. `scripts/tag-and-release.sh` now extracts just the bold lead sentence off each `- **Lead.** Detail...` CHANGELOG bullet for the release notes, matching the old style; the full explanation still lives in CHANGELOG.md. Backfilled concise notes for all 20 existing releases (v0.4.6 through v0.5.5) to match. (`scripts/tag-and-release.sh`, `CONTRIBUTING.md`)
+- **GitHub Release notes are now a short bullet list, not the full CHANGELOG entry.** Every release since v0.4.6 had pasted its entire CHANGELOG.md section (bold headers, rationale, file lists) verbatim as the GitHub Release notes — unlike the short, scannable one-liners releases had before v0.4.6. `scripts/tag-and-release.sh` now extracts just the bold lead sentence off each CHANGELOG bullet for the release notes, matching the old style; the full explanation still lives in CHANGELOG.md. Backfilled concise notes for all 20 existing releases (v0.4.6 through v0.5.5) to match. (`scripts/tag-and-release.sh`, `CONTRIBUTING.md`)
 
 ## [0.5.5] — 2026-08-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-bot",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/scripts/tag-and-release.sh
+++ b/scripts/tag-and-release.sh
@@ -27,7 +27,7 @@ fi
 # Release notes are a short bullet list for scanning, not the full CHANGELOG
 # entry: pull just the bold lead sentence off each "- **Lead.** Detail..."
 # bullet. The full explanation stays in CHANGELOG.md for anyone who wants it.
-NOTES="$(echo "$CHANGELOG_SECTION" | sed -n -E 's/^- \*\*(.*)\.\*\*.*/- \1/p')"
+NOTES="$(echo "$CHANGELOG_SECTION" | sed -n -E 's/^- \*\*([^*]*)\*\*.*/- \1/p')"
 
 if [ -z "$NOTES" ]; then
     echo "::error::CHANGELOG.md's $VERSION section has no '- **Lead.** ...' bullets to extract release notes from."


### PR DESCRIPTION
The bold-lead extraction added in v0.5.6 used a greedy (.*) that matched
through to the last closing bold marker in a CHANGELOG bullet instead of
the first, truncating release notes whenever a bullet's body text also
contained a bold span. Switched to a non-asterisk character class so it
always stops at the first closing marker. Also hand-corrected the live
v0.5.6 release notes on GitHub to match.
