### PR TITLE
v0.6.0 — re-trigger merge evaluation when checks complete

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -6,16 +6,16 @@ This document is a point-in-time health check of the `merge-bot` repository: wha
 
 ## Summary
 
-After the 2026-08-26 remediation push (v0.4.7 through v0.4.17: runtime fix, dependency upgrades, ESM migration, test coverage, `dist/` bundling, CI consolidation, `dependabot.yml`, `CODEOWNERS`/`SECURITY.md`) covered in this audit's prior revision, the same day's second half closed out the PR/issue backlog itself: all 9 open PRs were triaged to zero, one community feature (comment-triggered re-evaluation, #72) was ported to the current codebase and merged, a real bug it surfaced along the way was fixed, and a second, more fundamental bug was discovered and documented. A third pass (v0.5.1) then fixed #77, the confirmed crash-on-every-push bug that had been the top-priority open issue, and updated [BACKLOG.md](BACKLOG.md)'s shipping checklist to require linking/attributing/closing the GitHub issue behind any shipped item going forward. A fourth pass (v0.5.5, 2026-08-27) fixed #37's missing `requested_teams` handling and added a [MIGRATION.md](MIGRATION.md) guide for consumers still pinned to `v0.4.5`. **Zero PRs are open, zero stale branches remain on `origin`, and the two forks with any independent activity (`umegaya`, `comnoco`) have nothing left worth pulling in.** What remains is 6 long-standing community feature/bug issues (down from 8 — none of the rest touch code that moved this session) plus the still-open fork-merge-token limitation, all in [BACKLOG.md](BACKLOG.md).
+After the 2026-08-26 remediation push (v0.4.7 through v0.4.17: runtime fix, dependency upgrades, ESM migration, test coverage, `dist/` bundling, CI consolidation, `dependabot.yml`, `CODEOWNERS`/`SECURITY.md`) covered in this audit's prior revision, the same day's second half closed out the PR/issue backlog itself: all 9 open PRs were triaged to zero, one community feature (comment-triggered re-evaluation, #72) was ported to the current codebase and merged, a real bug it surfaced along the way was fixed, and a second, more fundamental bug was discovered and documented. A third pass (v0.5.1) then fixed #77, the confirmed crash-on-every-push bug that had been the top-priority open issue, and updated [BACKLOG.md](BACKLOG.md)'s shipping checklist to require linking/attributing/closing the GitHub issue behind any shipped item going forward. A fourth pass (v0.5.5, 2026-08-27) fixed #37's missing `requested_teams` handling and added a [MIGRATION.md](MIGRATION.md) guide for consumers still pinned to `v0.4.5`. A fifth pass (v0.6.0, 2026-08-27) closed #22 by re-fetching and re-evaluating a PR's associated pull requests on `check_suite` completion. **Zero PRs are open, zero stale branches remain on `origin`, and the two forks with any independent activity (`umegaya`, `comnoco`) have nothing left worth pulling in.** What remains is 5 long-standing community feature/bug issues (down from 8 — none of the rest touch code that moved this session) plus the still-open fork-merge-token limitation, all in [BACKLOG.md](BACKLOG.md).
 
 | Area | Status |
 |---|---|
-| Tests | ✅ Passing (56/56), 100% statement/branch coverage across `index.js` and `lib/` |
+| Tests | ✅ Passing (59/59), 100% statement/branch coverage across `index.js` and `lib/` |
 | Action runtime | ✅ `node20` |
 | Dependencies | ✅ `npm audit`: 0 vulnerabilities; `.github/dependabot.yml` scheduling weekly scans |
 | CI/CD | ✅ `test.yml` / `build-check.yml` / `version-check.yml` / `merge-bot.yml` (now also triggers on `issue_comment`, see below) |
 | Open PRs | 🟢 **0 open** — all 9 triaged this session (7 dependabot closed as superseded, #12 closed as stale, #72 ported and merged) |
-| Open issues | 🟢 8 open on GitHub as of this writing, but #77 (v0.5.1) and #37 (v0.5.5, this shipment) are fixed and will auto-close on merge, leaving 6 |
+| Open issues | 🟢 8 open on GitHub as of this writing, but #77 (v0.5.1), #37 (v0.5.5), and #22 (v0.6.0, this shipment) are fixed and will auto-close on merge, leaving 5 |
 | Repo hygiene | ✅ Zero stale branches on `origin` (was 8); `CODEOWNERS`, `SECURITY.md`, `dependabot.yml` all present |
 | Known issues (undocumented) | ✅ Fixed in v0.5.2: fork PRs couldn't be merged via the `labeled` trigger — a GitHub platform token restriction, not a code bug. See below. |
 | Docs | 🟡 CLAUDE.md and CONTRIBUTING.md both contain **stale, incorrect** claims about the current octokit API shape and pinned dependency version — see "Documentation drift" below. |
@@ -65,9 +65,9 @@ Checked the two forks with any independent activity beyond a stock fork:
 - **[umegaya/merge-bot](https://github.com/umegaya/merge-bot)** — nothing left to capture; its only unique work was #72, now merged.
 - **[comnoco/merge-bot](https://github.com/comnoco/merge-bot)** — diverged independently in 2022–2023 and did its own Node 12→16→20 runtime upgrade and dependency bumps, but every bit of it is superseded by this repo's own history (already on `node20`; their three open dependabot branches propose *older* versions than what's already in `package.json`). Never opened a PR against this repo, so none of it was ever proposed here. Nothing worth backporting.
 
-## Open issues (6, was 8)
+## Open issues (5, was 8)
 
-Re-checked against current code (`lib/pull.js`, `lib/config.js`, `index.js`). #77 (v0.5.1) and #37 (v0.5.5, this shipment) are fixed and will close automatically on merge (`Fixes #<n>` in each PR body) — the other 6 are unchanged, since none of this session's code changes touched the areas they report on.
+Re-checked against current code (`lib/pull.js`, `lib/config.js`, `index.js`). #77 (v0.5.1), #37 (v0.5.5), and #22 (v0.6.0, this shipment) are fixed and will close automatically on merge (`Fixes #<n>` in each PR body) — the other 5 are unchanged, since none of this session's code changes touched the areas they report on.
 
 | # | Title | Author | Opened | Still valid? |
 |---|---|---|---|---|
@@ -75,12 +75,12 @@ Re-checked against current code (`lib/pull.js`, `lib/config.js`, `index.js`). #7
 | [#59](https://github.com/squalrus/merge-bot/issues/59) | Time based allow/block of merges | alper (community) | 2021-06-15 | ✅ Still unimplemented |
 | [#56](https://github.com/squalrus/merge-bot/issues/56) | Allow merges even if the base branch changes | RevolutionTech (community) | 2021-04-28 | ✅ Still unimplemented |
 | ~~[#37](https://github.com/squalrus/merge-bot/issues/37)~~ | Not detecting reviews? | aaron-trout (community) | 2020-09-03 | ✅ **Fixed in v0.5.5** — `Pull` now reads `requested_teams` alongside `requested_reviewers`, so a pending CODEOWNERS team review blocks merge instead of being silently ignored |
-| [#22](https://github.com/squalrus/merge-bot/issues/22) | Re-trigger Action when checks complete | squalrus (you) | 2020-01-26 | ✅ Still true |
+| ~~[#22](https://github.com/squalrus/merge-bot/issues/22)~~ | Re-trigger Action when checks complete | squalrus (you) | 2020-01-26 | ✅ **Fixed in v0.6.0** — `index.js` now handles `check_suite` completion events, re-fetching and re-evaluating each associated pull request; the README's example workflow adds a `check_suite: [completed]` trigger |
 | [#14](https://github.com/squalrus/merge-bot/issues/14) | follow the configured required review count | Evanion (community) | 2019-12-20 | ✅ Still true |
 | [#13](https://github.com/squalrus/merge-bot/issues/13) | Update from base branch before merging. | Evanion (community) | 2019-12-20 | ✅ Still true |
 | [#7](https://github.com/squalrus/merge-bot/issues/7) | Feature: on commit, remove label(?) or Re-request review(?) | squalrus (you) | 2019-09-27 | ✅ Still true |
 
-**Recommendation:** with #77, #37, and the fork-merge-token limitation all shipped (v0.5.1, v0.5.5, v0.5.2), the remaining community feature/bug issues are all low-urgency at your own pace.
+**Recommendation:** with #77, #37, #22, and the fork-merge-token limitation all shipped (v0.5.1, v0.5.5, v0.6.0, v0.5.2), the remaining community feature/bug issues are all low-urgency at your own pace.
 
 ## Repository hygiene observations
 
@@ -108,6 +108,7 @@ Re-checked against current code (`lib/pull.js`, `lib/config.js`, `index.js`). #7
 5. ~~Fix the fork-merge-token limitation~~ — done 2026-08-26, shipped as v0.5.2 (`pull_request` → `pull_request_target` in `merge-bot.yml`).
 6. ~~Fix #37 (team-requested reviews not detected)~~ — done 2026-08-27, shipped as v0.5.5.
 7. Fix the CLAUDE.md/CONTRIBUTING.md stale-claims doc drift — small, prevents a future contributor from being misled.
-8. Work through the remaining community feature requests (#7, #13, #14, #22, #56, #59) at your own pace — none are urgent, all are still genuinely wanted as far as this audit can tell.
+8. ~~Fix #22 (re-trigger on check completion)~~ — done 2026-08-27, shipped as v0.6.0.
+9. Work through the remaining community feature requests (#7, #13, #14, #56, #59) at your own pace — none are urgent, all are still genuinely wanted as far as this audit can tell.
 
 These are tracked as individual items in [BACKLOG.md](BACKLOG.md).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -23,7 +23,6 @@ Tracks future features, improvements, and known bugs. Items here are not committ
 
 | Title | Effort | Value |
 |---|---|---|
-| [Re-trigger Action when checks complete](#re-trigger-action-when-checks-complete) | M | H |
 | [Maintain a floating major-version tag](#maintain-a-floating-major-version-tag) | S | M |
 | [Allow merges even if the base branch changes](#allow-merges-even-if-the-base-branch-changes) | S | M |
 | [Follow the configured required review count](#follow-the-configured-required-review-count) | S | M |
@@ -51,11 +50,6 @@ No open limitations.
 **Type:** Feature
 **Why** — Consumers currently either pin an exact tag (`@v0.4.5`) or float on `@main`. A moving major tag (e.g. `v0`) lets them pin `squalrus/merge-bot@v0` and pick up patch/minor releases automatically without tracking every release — the common convention for GitHub Actions (see `actions/checkout@v4`, etc.).
 **Notes:** On release, after `npm version` creates the exact tag, force-move the major tag to point at the new commit and push it: `git tag -f v0 <new-tag> && git push origin v0 --force`. Add this as a step in [CONTRIBUTING.md](CONTRIBUTING.md)'s release process, ideally automated in a release workflow rather than manual. Consider updating the README's example usage to recommend pinning the major tag instead of an exact version once this exists.
-
-### Re-trigger Action when checks complete
-**Type:** Feature
-**Why** — Reported in [#22](https://github.com/squalrus/merge-bot/issues/22). The action runs once per triggering event and never requeues itself; `.github/workflows/merge-bot.yml` doesn't listen for `check_suite`/`workflow_run` completion, so a check finishing after the bot's last run won't cause a re-evaluation — a PR can sit mergeable-but-unmerged until some unrelated event happens to retrigger it.
-**Notes:** Add `check_suite: [completed]` (and/or `workflow_run`) to the trigger list in `merge-bot.yml`. This is a core reliability gap for the action's primary use case (auto-merge gated on checks passing) — highest-value item in this section.
 
 ### Allow merges even if the base branch changes
 **Type:** Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 User-visible changes, newest first. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and [semver](https://semver.org/) versioning.
 
+## [0.6.0] — 2026-08-27
+
+### Added
+- **Re-trigger merge evaluation when checks complete.** Reported in [#22](https://github.com/squalrus/merge-bot/issues/22) by [@squalrus](https://github.com/squalrus). The action only ever ran once per triggering event and never requeued itself, so a PR could sit mergeable-but-unmerged until some unrelated event (a new push, a review) happened to retrigger it — a check finishing after the bot's last run wouldn't cause a re-evaluation on its own. `index.js` now handles `check_suite` completion events: since that payload only lists minimal pull request refs (no labels or reviewer data), each associated pull request is re-fetched in full and re-evaluated. The README's example workflow now includes `check_suite: [completed]` as a trigger, with a job-level guard so runs with no associated pull request are skipped. (`index.js`, `README.md`, `__mocks__/pull/payload-check-suite.js`, `__mocks__/pull/payload-check-suite-multi.js`, `__mocks__/pull/payload-check-suite-empty.js`, `__tests__/index.test.js`)
+
 ## [0.5.7] — 2026-08-27
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,6 +28,8 @@ Not merging fork PRs? Skip this, `pull_request` still works.
 
 **Retry via PR comment** — add an `issue_comment` trigger to retry a merge that failed with "Base branch was modified." See the README's [Retrying via a PR comment](README.md#retrying-via-a-pr-comment) section.
 
+**Re-evaluate when checks complete** — add a `check_suite: [completed]` trigger (with a job guard) so a mergeable PR is picked up the moment its checks finish, instead of waiting for another event to happen to retrigger it. See the README's [Example usage](README.md#example-usage) section.
+
 ## Everything else
 
 Node runtime, fork check lookups, a crash on non-PR events — all fixed transparently, nothing to do.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,13 @@ on:
     types:
       - dismissed
       - submitted
+  check_suite:
+    types:
+      - completed
 
 jobs:
   merge:
+    if: github.event_name != 'check_suite' || github.event.check_suite.pull_requests[0] != null
     runs-on: ubuntu-latest
     name: Merge
     steps:
@@ -94,6 +98,8 @@ jobs:
 
 `pull_request_target` (rather than `pull_request`) is required for merge-bot to work on pull requests from forks: GitHub always issues a read-only `GITHUB_TOKEN` for fork-originated `pull_request` events, which makes the actual merge fail even when merge-bot judges the PR mergeable. `pull_request_target` runs with your repo's normal token permissions instead. This is only safe because the workflow above never checks out or executes the fork's code — it just runs the trusted `merge-bot` action against webhook data. If you add a step that checks out `github.event.pull_request.head.sha` to this workflow, you'd be executing untrusted fork code with write access to your repo; don't do that here.
 
+`check_suite: [completed]` is what lets merge-bot re-evaluate a PR the moment its checks finish, rather than waiting for some unrelated event (another push, a new review) to happen to retrigger it — the usual gap when `checks_enabled: true` and a check runs longer than the PR's other requirements take to satisfy. A check suite fires for every commit in the repo, not just ones tied to open PRs, so its payload lists the (possibly empty) set of pull requests it's associated with; merge-bot fetches and re-evaluates each one in full. The job's `if` above skips runs with no associated pull request so they don't spend a runner for nothing.
+
 ### Retrying via a PR comment
 
 Merging can occasionally fail with a transient `Base branch was modified` error (typically when multiple merge-bot runs land close together). To let a comment on the pull request re-trigger evaluation, add `issue_comment` to the workflow's triggers, guarding the job so it only runs for comments on pull requests (`issue_comment` also fires for comments on plain issues, which have no pull request to evaluate):
@@ -109,6 +115,12 @@ jobs:
     if: github.event.issue.pull_request
     runs-on: ubuntu-latest
     ...
+```
+
+If you're combining this with the `check_suite` trigger above, `&&` the two conditions together rather than adding a second `if:` key (YAML keeps only the last one):
+
+```yaml
+if: (github.event_name != 'issue_comment' || github.event.issue.pull_request) && (github.event_name != 'check_suite' || github.event.check_suite.pull_requests[0] != null)
 ```
 
 ## Development

--- a/__mocks__/pull/payload-check-suite-empty.js
+++ b/__mocks__/pull/payload-check-suite-empty.js
@@ -1,0 +1,14 @@
+export default {
+    "action": "completed",
+    "check_suite": {
+        "status": "completed",
+        "conclusion": "success",
+        "pull_requests": []
+    },
+    "repository": {
+        "name": "merge-bot",
+        "owner": {
+            "login": "squalrus"
+        }
+    }
+};

--- a/__mocks__/pull/payload-check-suite-multi.js
+++ b/__mocks__/pull/payload-check-suite-multi.js
@@ -1,0 +1,21 @@
+export default {
+    "action": "completed",
+    "check_suite": {
+        "status": "completed",
+        "conclusion": "success",
+        "pull_requests": [
+            {
+                "number": 20
+            },
+            {
+                "number": 21
+            }
+        ]
+    },
+    "repository": {
+        "name": "merge-bot",
+        "owner": {
+            "login": "squalrus"
+        }
+    }
+};

--- a/__mocks__/pull/payload-check-suite.js
+++ b/__mocks__/pull/payload-check-suite.js
@@ -1,0 +1,18 @@
+export default {
+    "action": "completed",
+    "check_suite": {
+        "status": "completed",
+        "conclusion": "success",
+        "pull_requests": [
+            {
+                "number": 20
+            }
+        ]
+    },
+    "repository": {
+        "name": "merge-bot",
+        "owner": {
+            "login": "squalrus"
+        }
+    }
+};

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -3,6 +3,9 @@ import { jest } from '@jest/globals';
 import payloadDefault from '../__mocks__/pull/payload-default.js';
 import payloadFork from '../__mocks__/pull/payload-fork.js';
 import payloadIssueComment from '../__mocks__/pull/payload-issue-comment.js';
+import payloadCheckSuite from '../__mocks__/pull/payload-check-suite.js';
+import payloadCheckSuiteMulti from '../__mocks__/pull/payload-check-suite-multi.js';
+import payloadCheckSuiteEmpty from '../__mocks__/pull/payload-check-suite-empty.js';
 import reviewsNone from '../__mocks__/pull/reviews-none.js';
 import checks0 from '../__mocks__/checks/check-0.js';
 
@@ -135,6 +138,60 @@ test('comment on a pull request fetches it and merges it', async () => {
     expect(octokit.rest.pulls.merge).toHaveBeenCalledWith(expect.objectContaining({
         pull_number: 20
     }));
+});
+
+test('check suite completion fetches its associated pull request and merges it', async () => {
+    const octokit = makeOctokit();
+    await runIndex({
+        inputs: { labels: 'ready' },
+        payload: payloadCheckSuite,
+        octokit
+    });
+
+    expect(octokit.rest.pulls.get).toHaveBeenCalledWith({
+        owner: 'squalrus',
+        repo: 'merge-bot',
+        pull_number: 20
+    });
+    expect(octokit.rest.pulls.merge).toHaveBeenCalledWith(expect.objectContaining({
+        pull_number: 20
+    }));
+});
+
+test('check suite completion re-evaluates every associated pull request', async () => {
+    const octokit = makeOctokit({
+        pulls: {
+            get: jest.fn((params) => Promise.resolve({
+                data: { ...payloadDefault.pull_request, number: params.pull_number }
+            })),
+            listReviews: jest.fn().mockResolvedValue(reviewsNone),
+            merge: jest.fn().mockResolvedValue({})
+        }
+    });
+
+    await runIndex({
+        inputs: { labels: 'ready' },
+        payload: payloadCheckSuiteMulti,
+        octokit
+    });
+
+    expect(octokit.rest.pulls.get).toHaveBeenCalledWith(expect.objectContaining({ pull_number: 20 }));
+    expect(octokit.rest.pulls.get).toHaveBeenCalledWith(expect.objectContaining({ pull_number: 21 }));
+    expect(octokit.rest.pulls.merge).toHaveBeenCalledWith(expect.objectContaining({ pull_number: 20 }));
+    expect(octokit.rest.pulls.merge).toHaveBeenCalledWith(expect.objectContaining({ pull_number: 21 }));
+});
+
+test('check suite completion with no associated pull requests is a clean no-op', async () => {
+    const octokit = makeOctokit();
+    const { core } = await runIndex({
+        inputs: { labels: 'ready' },
+        payload: payloadCheckSuiteEmpty,
+        octokit
+    });
+
+    expect(octokit.rest.pulls.get).not.toHaveBeenCalled();
+    expect(octokit.rest.pulls.merge).not.toHaveBeenCalled();
+    expect(core.setFailed).not.toHaveBeenCalled();
 });
 
 test('comment on a plain issue does not attempt to fetch a pull request', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -37206,6 +37206,77 @@ const renderMessage = (action, config, pull) => {
 
 
 
+async function fetchPullRequest(octokit, owner, repo, pull_number) {
+    console.log(`[info] fetching pull request #${pull_number}`);
+    const response = await octokit.rest.pulls.get({ owner, repo, pull_number });
+    return response.data;
+}
+
+async function processPullRequest(payload, config, octokit) {
+    const pull = new lib_pull(payload);
+    console.log(`[data] pull (payload): ${JSON.stringify(pull)}`);
+
+    console.log(`[info] get reviews`);
+    const reviews = await octokit.rest.pulls.listReviews({
+        owner: pull.owner,
+        repo: pull.repo,
+        pull_number: pull.pull_number
+    });
+
+    console.log(`[info] get checks`);
+    const checks = await octokit.rest.checks.listForRef({
+        owner: pull.owner,
+        repo: pull.repo,
+        ref: pull.ref
+    });
+
+    pull.compileReviews(reviews);
+    pull.compileChecks(checks);
+    console.log(`[data] pull (checks + reviews): ${JSON.stringify(pull)}`);
+
+    console.log(`merge: ${pull.canMerge(config)}`);
+
+    if (config.test_mode) {
+
+        // comment in test mode
+        await octokit.rest.issues.createComment({
+            owner: pull.owner,
+            repo: pull.repo,
+            issue_number: pull.pull_number,
+            body: message(payload.action, config, pull)
+        });
+
+    } else {
+        if (pull.canMerge(config)) {
+
+            // merge the pull request
+            console.log(`[info] merge start`);
+            await octokit.rest.pulls.merge({
+                owner: pull.owner,
+                repo: pull.repo,
+                pull_number: pull.pull_number,
+                merge_method: config.merge_method
+            });
+            console.log(`[info] merge complete`);
+
+            if (config.delete_source_branch) {
+                if (pull.headRepoId !== pull.baseRepoId) {
+                    console.log(`[warning] unable to delete branch from fork, branch retained`);
+                } else {
+                    // delete the branch
+                    console.log(`[info] delete start`);
+                    await octokit.rest.git.deleteRef({
+                        owner: pull.owner,
+                        repo: pull.repo,
+                        ref: pull.ref
+                    });
+                    console.log(`[info] delete complete`);
+                }
+            }
+        }
+    }
+}
+
 async function run() {
     try {
         const payload = github_context.payload;
@@ -37218,17 +37289,31 @@ async function run() {
         const token = getInput('GITHUB_TOKEN');
         const octokit = getOctokit(token);
 
+        const owner = payload.repository.owner.login;
+        const repo = payload.repository.name;
+
         if (payload.issue && payload.issue.pull_request) {
 
             // triggered by a comment on a pull request (issue_comment event) — that
             // payload has no pull_request object, so fetch it and splice it in
             console.log(`[info] comment on pull request #${payload.issue.number}, fetching pull request`);
-            const response = await octokit.rest.pulls.get({
-                owner: payload.repository.owner.login,
-                repo: payload.repository.name,
-                pull_number: payload.issue.number
-            });
-            payload.pull_request = response.data;
+            payload.pull_request = await fetchPullRequest(octokit, owner, repo, payload.issue.number);
+        }
+
+        if (payload.check_suite) {
+
+            // triggered by a check suite completing (check_suite event) — that
+            // payload lists only minimal pull request refs (no labels/reviewers),
+            // and a suite can be associated with more than one open pull request,
+            // so re-fetch and re-evaluate each one in full
+            const refs = payload.check_suite.pull_requests;
+            console.log(`[info] check suite completed, re-evaluating ${refs.length} associated pull request(s)`);
+
+            for (const ref of refs) {
+                const pull_request = await fetchPullRequest(octokit, owner, repo, ref.number);
+                await processPullRequest({ ...payload, pull_request }, config, octokit);
+            }
+            return;
         }
 
         if (!payload.pull_request) {
@@ -37236,68 +37321,7 @@ async function run() {
             return;
         }
 
-        const pull = new lib_pull(payload);
-        console.log(`[data] pull (payload): ${JSON.stringify(pull)}`);
-
-        console.log(`[info] get reviews`);
-        const reviews = await octokit.rest.pulls.listReviews({
-            owner: pull.owner,
-            repo: pull.repo,
-            pull_number: pull.pull_number
-        });
-
-        console.log(`[info] get checks`);
-        const checks = await octokit.rest.checks.listForRef({
-            owner: pull.owner,
-            repo: pull.repo,
-            ref: pull.ref
-        });
-
-        pull.compileReviews(reviews);
-        pull.compileChecks(checks);
-        console.log(`[data] pull (checks + reviews): ${JSON.stringify(pull)}`);
-
-        console.log(`merge: ${pull.canMerge(config)}`);
-
-        if (config.test_mode) {
-
-            // comment in test mode
-            await octokit.rest.issues.createComment({
-                owner: pull.owner,
-                repo: pull.repo,
-                issue_number: pull.pull_number,
-                body: message(github_context.payload.action, config, pull)
-            });
-
-        } else {
-            if (pull.canMerge(config)) {
-
-                // merge the pull request
-                console.log(`[info] merge start`);
-                await octokit.rest.pulls.merge({
-                    owner: pull.owner,
-                    repo: pull.repo,
-                    pull_number: pull.pull_number,
-                    merge_method: config.merge_method
-                });
-                console.log(`[info] merge complete`);
-
-                if (config.delete_source_branch) {
-                    if (pull.headRepoId !== pull.baseRepoId) {
-                        console.log(`[warning] unable to delete branch from fork, branch retained`);
-                    } else {
-                        // delete the branch
-                        console.log(`[info] delete start`);
-                        await octokit.rest.git.deleteRef({
-                            owner: pull.owner,
-                            repo: pull.repo,
-                            ref: pull.ref
-                        });
-                        console.log(`[info] delete complete`);
-                    }
-                }
-            }
-        }
+        await processPullRequest(payload, config, octokit);
     } catch (error) {
         setFailed(error.message);
     }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,77 @@ import Config from './lib/config.js';
 import Pull from './lib/pull.js';
 import renderMessage from './lib/message.js';
 
+async function fetchPullRequest(octokit, owner, repo, pull_number) {
+    console.log(`[info] fetching pull request #${pull_number}`);
+    const response = await octokit.rest.pulls.get({ owner, repo, pull_number });
+    return response.data;
+}
+
+async function processPullRequest(payload, config, octokit) {
+    const pull = new Pull(payload);
+    console.log(`[data] pull (payload): ${JSON.stringify(pull)}`);
+
+    console.log(`[info] get reviews`);
+    const reviews = await octokit.rest.pulls.listReviews({
+        owner: pull.owner,
+        repo: pull.repo,
+        pull_number: pull.pull_number
+    });
+
+    console.log(`[info] get checks`);
+    const checks = await octokit.rest.checks.listForRef({
+        owner: pull.owner,
+        repo: pull.repo,
+        ref: pull.ref
+    });
+
+    pull.compileReviews(reviews);
+    pull.compileChecks(checks);
+    console.log(`[data] pull (checks + reviews): ${JSON.stringify(pull)}`);
+
+    console.log(`merge: ${pull.canMerge(config)}`);
+
+    if (config.test_mode) {
+
+        // comment in test mode
+        await octokit.rest.issues.createComment({
+            owner: pull.owner,
+            repo: pull.repo,
+            issue_number: pull.pull_number,
+            body: renderMessage(payload.action, config, pull)
+        });
+
+    } else {
+        if (pull.canMerge(config)) {
+
+            // merge the pull request
+            console.log(`[info] merge start`);
+            await octokit.rest.pulls.merge({
+                owner: pull.owner,
+                repo: pull.repo,
+                pull_number: pull.pull_number,
+                merge_method: config.merge_method
+            });
+            console.log(`[info] merge complete`);
+
+            if (config.delete_source_branch) {
+                if (pull.headRepoId !== pull.baseRepoId) {
+                    console.log(`[warning] unable to delete branch from fork, branch retained`);
+                } else {
+                    // delete the branch
+                    console.log(`[info] delete start`);
+                    await octokit.rest.git.deleteRef({
+                        owner: pull.owner,
+                        repo: pull.repo,
+                        ref: pull.ref
+                    });
+                    console.log(`[info] delete complete`);
+                }
+            }
+        }
+    }
+}
+
 async function run() {
     try {
         const payload = github.context.payload;
@@ -17,17 +88,31 @@ async function run() {
         const token = core.getInput('GITHUB_TOKEN');
         const octokit = github.getOctokit(token);
 
+        const owner = payload.repository.owner.login;
+        const repo = payload.repository.name;
+
         if (payload.issue && payload.issue.pull_request) {
 
             // triggered by a comment on a pull request (issue_comment event) — that
             // payload has no pull_request object, so fetch it and splice it in
             console.log(`[info] comment on pull request #${payload.issue.number}, fetching pull request`);
-            const response = await octokit.rest.pulls.get({
-                owner: payload.repository.owner.login,
-                repo: payload.repository.name,
-                pull_number: payload.issue.number
-            });
-            payload.pull_request = response.data;
+            payload.pull_request = await fetchPullRequest(octokit, owner, repo, payload.issue.number);
+        }
+
+        if (payload.check_suite) {
+
+            // triggered by a check suite completing (check_suite event) — that
+            // payload lists only minimal pull request refs (no labels/reviewers),
+            // and a suite can be associated with more than one open pull request,
+            // so re-fetch and re-evaluate each one in full
+            const refs = payload.check_suite.pull_requests;
+            console.log(`[info] check suite completed, re-evaluating ${refs.length} associated pull request(s)`);
+
+            for (const ref of refs) {
+                const pull_request = await fetchPullRequest(octokit, owner, repo, ref.number);
+                await processPullRequest({ ...payload, pull_request }, config, octokit);
+            }
+            return;
         }
 
         if (!payload.pull_request) {
@@ -35,68 +120,7 @@ async function run() {
             return;
         }
 
-        const pull = new Pull(payload);
-        console.log(`[data] pull (payload): ${JSON.stringify(pull)}`);
-
-        console.log(`[info] get reviews`);
-        const reviews = await octokit.rest.pulls.listReviews({
-            owner: pull.owner,
-            repo: pull.repo,
-            pull_number: pull.pull_number
-        });
-
-        console.log(`[info] get checks`);
-        const checks = await octokit.rest.checks.listForRef({
-            owner: pull.owner,
-            repo: pull.repo,
-            ref: pull.ref
-        });
-
-        pull.compileReviews(reviews);
-        pull.compileChecks(checks);
-        console.log(`[data] pull (checks + reviews): ${JSON.stringify(pull)}`);
-
-        console.log(`merge: ${pull.canMerge(config)}`);
-
-        if (config.test_mode) {
-
-            // comment in test mode
-            await octokit.rest.issues.createComment({
-                owner: pull.owner,
-                repo: pull.repo,
-                issue_number: pull.pull_number,
-                body: renderMessage(github.context.payload.action, config, pull)
-            });
-
-        } else {
-            if (pull.canMerge(config)) {
-
-                // merge the pull request
-                console.log(`[info] merge start`);
-                await octokit.rest.pulls.merge({
-                    owner: pull.owner,
-                    repo: pull.repo,
-                    pull_number: pull.pull_number,
-                    merge_method: config.merge_method
-                });
-                console.log(`[info] merge complete`);
-
-                if (config.delete_source_branch) {
-                    if (pull.headRepoId !== pull.baseRepoId) {
-                        console.log(`[warning] unable to delete branch from fork, branch retained`);
-                    } else {
-                        // delete the branch
-                        console.log(`[info] delete start`);
-                        await octokit.rest.git.deleteRef({
-                            owner: pull.owner,
-                            repo: pull.repo,
-                            ref: pull.ref
-                        });
-                        console.log(`[info] delete complete`);
-                    }
-                }
-            }
-        }
+        await processPullRequest(payload, config, octokit);
     } catch (error) {
         core.setFailed(error.message);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merge-bot",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "description": "",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- Adds `check_suite: [completed]` handling so a PR's merge eligibility is re-evaluated as soon as its checks finish, instead of waiting for some unrelated event to happen to retrigger it — the action fetches and re-evaluates each pull request associated with the completed check suite.
- Updates the README's example workflow with the new trigger and a job-level guard, and adds a matching optional bullet to MIGRATION.md.
- Updates AUDIT.md to reflect #22 as fixed.

Fixes #22

## Test plan
- [x] `npm test` (59/59 passing)
- [x] `npm run coverage` (100% statement/branch/function/line across `index.js` and `lib/`)
- [x] `npm run lint`
- [x] `npm run build` (dist/index.js rebuilt and committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)